### PR TITLE
feat: `createClient` REST client using JS proxies

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,6 +234,10 @@ const users = await api.users.get<UserResponse>()
 // For GET request you can add search params
 // <baseURL>/users?search=john
 const users = await api.users.get<UserResponse>({ search: 'john' })
+
+// Chains can get as deep as you wish
+// <baseURL>/deeply/nested
+const data = await api.deeply.nested.get()
 ```
 
 To include dynamic API path segments, you have two options:

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ yarn add ofetch
 Import:
 
 ```js
-// ESM / Typescript
+// ESM / TypeScript
 import { ofetch } from 'ofetch'
 
 // CommonJS

--- a/README.md
+++ b/README.md
@@ -241,7 +241,7 @@ You can add/overwrite `$fetch` options on a method-level as well:
 ```js
 const response = await api.users.get({
   headers: {
-    Accept: 'application/json'
+    'Cache-Control': 'no-cache'
   }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -213,10 +213,10 @@ apiFetch('/test') // Same as ofetch('/test', { baseURL: '/api' })
 
 ## 🪵 REST Client With `createClient`
 
-You can use `ohmyfetch` as a minimal, type-safe REST client for any given API. The API builder uses JS proxies under the hood.
+You can use `ofetch` as a minimal, type-safe REST client for any given API. The API builder uses JS proxies under the hood.
 
 ```js
-import { createClient } from 'ohmyfetch'
+import { createClient } from 'ofetch'
 
 const api = createClient({
   // Set optional defaults for `$fetch`

--- a/README.md
+++ b/README.md
@@ -218,10 +218,13 @@ You can use `ohmyfetch` as a minimal, type-safe REST client for any given API. T
 ```js
 import { createClient } from 'ohmyfetch'
 
-const api = createClient('<baseURL>', {
+const api = createClient({
   // Set optional defaults for `$fetch`
+  baseURL: '<baseURL>'
 })
 ```
+
+The `baseURL` will default to `/` if not set.
 
 ### Path Segment Chaining
 

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 
 A better fetch API. Works on node, browser and workers.
 
+## 🧩 Features
+
+- 🦾 Works in the browser, workers and Node.js
+- 🪵 [Type-safe REST client](#-rest-client)
+
 ## 🚀 Quick Start
 
 Install:
@@ -168,7 +173,6 @@ await ofetch('/api', {
 })
 ```
 
-
 ### `onResponse({ request, options, response })`
 
 `onResponse` will be called after `fetch` call and parsing body.
@@ -205,6 +209,41 @@ This utility is useful if you need to use common options across several fetch ca
 const apiFetch = ofetch.create({ baseURL: '/api' })
 
 apiFetch('/test') // Same as ofetch('/test', { baseURL: '/api' })
+```
+
+## 🪵 REST client
+
+You can build a minimal, type-safe REST client for any given API. It uses JS proxies under the hood.
+
+```js
+import { createClient } from 'ohmyfetch';
+
+const api = createApi('<baseURL>', {
+  // Set optional defaults for `$fetch`
+});
+
+// GET request to <baseURL>/users
+const allUsers = await api.users.get()
+
+// Typed GET request to <baseURL>/users/1
+const userId = 1
+// … using the chain syntax:
+const user = await api.users(userId).get<UserResponse>()
+// … or the bracket syntax:
+const user = await api.users[`${userId}`].get<UserResponse>()
+
+// POST request to <baseURL>/users
+const response = await api.users.post({ name: 'foo' })
+```
+
+You can add/overwrite `$fetch` options on a method-level as well:
+
+```js
+const response = await api.users.get({
+  headers: {
+    Accept: 'application/json'
+  }
+})
 ```
 
 ## 💡 Adding headers

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A better fetch API. Works on node, browser and workers.
 
 ## 🧩 Features
 
-- 🦾 Works in the browser, workers and Node.js
-- 🪵 [Type-safe REST client](#-rest-client)
+- 🦾 Works everywhere: browser, workers and Node.js
+- 🪵 [Type-safe REST client](#-rest-client-with-createclient)
 
 ## 🚀 Quick Start
 
@@ -199,7 +199,7 @@ await ofetch('/api', {
 })
 ```
 
-## ✔️ Create fetch with default options
+## ✔️ Create Fetch With Default Options
 
 This utility is useful if you need to use common options across several fetch calls.
 
@@ -211,30 +211,62 @@ const apiFetch = ofetch.create({ baseURL: '/api' })
 apiFetch('/test') // Same as ofetch('/test', { baseURL: '/api' })
 ```
 
-## 🪵 REST client
+## 🪵 REST Client With `createClient`
 
-You can build a minimal, type-safe REST client for any given API. It uses JS proxies under the hood.
+You can use `ohmyfetch` as a minimal, type-safe REST client for any given API. The API builder uses JS proxies under the hood.
 
 ```js
-import { createClient } from 'ohmyfetch';
+import { createClient } from 'ohmyfetch'
 
-const api = createApi('<baseURL>', {
+const api = createClient('<baseURL>', {
   // Set optional defaults for `$fetch`
-});
+})
+```
 
+### Path Segment Chaining
+
+Chain single path segments or path ids by a dot. You can even type the response of your request!
+
+```js
 // GET request to <baseURL>/users
-const allUsers = await api.users.get()
+const users = await api.users.get<UserResponse>()
 
+// For GET request you can add search params
+// <baseURL>/users?search=john
+const users = await api.users.get<UserResponse>({ search: 'john' })
+```
+
+To include dynamic API path segments, you have two options:
+
+```js
 // Typed GET request to <baseURL>/users/1
 const userId = 1
 // … using the chain syntax:
 const user = await api.users(userId).get<UserResponse>()
 // … or the bracket syntax:
 const user = await api.users[`${userId}`].get<UserResponse>()
+```
 
+### HTTP Request Methods
+
+Add the appropriate method to the end of your API call. The following methods are supported:
+
+- `get()`
+- `post()`
+- `put()`
+- `delete()`
+- `patch()`
+
+### Payload Requests
+
+For HTTP request methods supporting a payload, add it to the method call:
+
+```js
 // POST request to <baseURL>/users
 const response = await api.users.post({ name: 'foo' })
 ```
+
+### Overwrite Default Options
 
 You can add/overwrite `$fetch` options on a method-level as well:
 
@@ -246,7 +278,7 @@ const response = await api.users.get({
 })
 ```
 
-## 💡 Adding headers
+## 💡 Adding Headers
 
 By using `headers` option, `ofetch` adds extra headers in addition to the request default headers:
 

--- a/src/base.ts
+++ b/src/base.ts
@@ -1,2 +1,3 @@
 export * from "./fetch";
+export * from "./builder";
 export * from "./error";

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -41,16 +41,10 @@ export function createClient<R extends ResponseType = 'json'> (
           data?: RequestInit['body'] | Record<string, any>,
           opts: FetchOptions<R> = {}
         ) => {
-          switch (method) {
-            case 'GET':
-              if (data) {
-                url = withQuery(url, data as QueryObject)
-              }
-              break
-            case 'POST':
-            case 'PUT':
-            case 'PATCH':
-              opts.body = data
+          if (method === 'GET' && data) {
+            url = withQuery(url, data as QueryObject)
+          } else if (['POST', 'PUT', 'PATCH'].includes(method)) {
+            opts.body = data
           }
 
           opts.method = method

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,0 +1,68 @@
+import { resolveURL, withQuery } from 'ufo'
+import type { QueryObject } from 'ufo'
+import type { FetchOptions } from './fetch'
+import type { ResponseType, MappedType } from './types'
+import { $fetch } from './undici'
+
+export type ClientMethodHandler = <T = any, R extends ResponseType = 'json'>(
+  data?: RequestInit['body'] | Record<string, any>,
+  opts?: Omit<FetchOptions<R>, 'baseURL' | 'method'>
+) => Promise<MappedType<R, T>>
+
+export type ClientBuilder = {
+  [key: string]: ClientBuilder;
+  (...segmentsOrIds: (string | number)[]): ClientBuilder
+} & {
+  get: ClientMethodHandler
+  post: ClientMethodHandler
+  put: ClientMethodHandler
+  delete: ClientMethodHandler
+  patch: ClientMethodHandler
+}
+
+export function createClient<R extends ResponseType = 'json'> (
+  url: string,
+  defaults: Omit<FetchOptions<R>, 'method'> = {}
+): ClientBuilder {
+  // Callable internal target required to use `apply` on it
+  const internalTarget = (() => {}) as ClientBuilder
+
+  const p = (url: string): ClientBuilder =>
+    new Proxy(internalTarget, {
+      get (_target, key: string) {
+        const method = key.toUpperCase()
+
+        if (!['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].includes(method)) {
+          return p(resolveURL(url, key))
+        }
+
+        const handler: ClientMethodHandler = <T = any, R extends ResponseType = 'json'>(
+          data?: RequestInit['body'] | Record<string, any>,
+          opts: Omit<FetchOptions<R>, 'baseURL' | 'method'> = {}
+        ) => {
+          switch (method) {
+            case 'GET':
+              if (data) { url = withQuery(url, data as QueryObject) }
+              break
+            case 'POST':
+            case 'PUT':
+            case 'PATCH':
+              opts.body = data
+          }
+
+          return $fetch<T, R>(url, {
+            ...(defaults as unknown as FetchOptions<R>),
+            ...opts,
+            method
+          })
+        }
+
+        return handler
+      },
+      apply (_target, _thisArg, args: (string | number)[] = []) {
+        return p(resolveURL(url, ...args.map(i => `${i}`)))
+      }
+    })
+
+  return p(url)
+}

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -50,8 +50,8 @@ export function createClient<R extends ResponseType = "json"> (
             ...(globalOptions as FetchOptions<R>),
             ...options,
             headers: {
-              ...headersToObject(globalOptions.headers || {}),
-              ...headersToObject(options.headers || {})
+              ...headersToObject(globalOptions.headers),
+              ...headersToObject(options.headers)
             },
             method
           });

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -32,7 +32,7 @@ export function createClient<R extends ResponseType = "json"> (
       get (_target, key: string) {
         const method = key.toUpperCase();
 
-        if (!["GET", "POST", "PUT", "DELETE", "PATCH"].includes(method)) {
+        if (method !== "GET" && !isPayloadMethod(method)) {
           return p(resolveURL(url, key));
         }
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -59,5 +59,5 @@ export function createClient<R extends ResponseType = 'json'> (
     })
   }
 
-  return p(globalOptions.baseURL ?? '/')
+  return p(globalOptions.baseURL || '/')
 }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -5,30 +5,30 @@ import type { FetchOptions } from './fetch'
 import type { ResponseType, MappedType } from './types'
 import { $fetch } from './undici'
 
-export type ClientMethodHandler = <T = any, R extends ResponseType = 'json'>(
+export type ApiClientMethodHandler = <T = any, R extends ResponseType = 'json'>(
   data?: RequestInit['body'] | Record<string, any>,
   opts?: Omit<FetchOptions<R>, 'baseURL' | 'method'>
 ) => Promise<MappedType<R, T>>
 
-export type ClientBuilder = {
-  [key: string]: ClientBuilder;
-  (...segmentsOrIds: (string | number)[]): ClientBuilder
+export type ApiClientBuilder = {
+  [key: string]: ApiClientBuilder;
+  (...segmentsOrIds: (string | number)[]): ApiClientBuilder
 } & {
-  get: ClientMethodHandler
-  post: ClientMethodHandler
-  put: ClientMethodHandler
-  delete: ClientMethodHandler
-  patch: ClientMethodHandler
+  get: ApiClientMethodHandler
+  post: ApiClientMethodHandler
+  put: ApiClientMethodHandler
+  delete: ApiClientMethodHandler
+  patch: ApiClientMethodHandler
 }
 
 export function createClient<R extends ResponseType = 'json'> (
   url: string,
   defaults: Omit<FetchOptions<R>, 'method'> = {}
-): ClientBuilder {
+): ApiClientBuilder {
   // Callable internal target required to use `apply` on it
-  const internalTarget = (() => {}) as ClientBuilder
+  const internalTarget = (() => {}) as ApiClientBuilder
 
-  const p = (url: string): ClientBuilder =>
+  const p = (url: string): ApiClientBuilder =>
     new Proxy(internalTarget, {
       get (_target, key: string) {
         const method = key.toUpperCase()
@@ -37,7 +37,7 @@ export function createClient<R extends ResponseType = 'json'> (
           return p(resolveURL(url, key))
         }
 
-        const handler: ClientMethodHandler = <T = any, R extends ResponseType = 'json'>(
+        const handler: ApiClientMethodHandler = <T = any, R extends ResponseType = 'json'>(
           data?: RequestInit['body'] | Record<string, any>,
           opts: FetchOptions<R> = {}
         ) => {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -50,8 +50,8 @@ export function createClient<R extends ResponseType = 'json'> (
             ...(globalOptions as FetchOptions<R>),
             ...opts,
             headers: {
-              ...(headersToObject(globalOptions.headers) || {}),
-              ...(headersToObject(opts.headers) || {})
+              ...headersToObject(globalOptions.headers || {}),
+              ...headersToObject(opts.headers || {})
             },
             method
           })

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -3,7 +3,7 @@ import type { QueryObject } from "ufo";
 import { headersToObject, isPayloadMethod } from "./utils";
 import type { FetchOptions } from "./fetch";
 import type { ResponseType, MappedType } from "./types";
-import { $fetch } from "./undici";
+import { $fetch } from "./";
 
 export type ClientMethodHandler = <T = any, R extends ResponseType = "json">(
   data?: RequestInit["body"] | Record<string, any>,

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -8,35 +8,38 @@ import { $fetch } from "./";
 export type ClientMethodHandler = <T = any, R extends ResponseType = "json">(
   data?: RequestInit["body"] | Record<string, any>,
   options?: Omit<FetchOptions<R>, "baseURL" | "method">
-) => Promise<MappedType<R, T>>
+) => Promise<MappedType<R, T>>;
 
 export type ClientBuilder = {
   [key: string]: ClientBuilder;
-  (...segmentsOrIds: (string | number)[]): ClientBuilder
+  (...segmentsOrIds: (string | number)[]): ClientBuilder;
 } & {
-  get: ClientMethodHandler
-  post: ClientMethodHandler
-  put: ClientMethodHandler
-  delete: ClientMethodHandler
-  patch: ClientMethodHandler
-}
+  get: ClientMethodHandler;
+  post: ClientMethodHandler;
+  put: ClientMethodHandler;
+  delete: ClientMethodHandler;
+  patch: ClientMethodHandler;
+};
 
-export function createClient<R extends ResponseType = "json"> (
+export function createClient<R extends ResponseType = "json">(
   globalOptions: Omit<FetchOptions<R>, "method"> = {}
 ): ClientBuilder {
   // Callable internal target required to use `apply` on it
   const internalTarget = (() => {}) as ClientBuilder;
 
-  function p (url: string): ClientBuilder {
+  function p(url: string): ClientBuilder {
     return new Proxy(internalTarget, {
-      get (_target, key: string) {
+      get(_target, key: string) {
         const method = key.toUpperCase();
 
         if (method !== "GET" && !isPayloadMethod(method)) {
           return p(resolveURL(url, key));
         }
 
-        const handler: ClientMethodHandler = <T = any, R extends ResponseType = "json">(
+        const handler: ClientMethodHandler = <
+          T = any,
+          R extends ResponseType = "json"
+        >(
           data?: RequestInit["body"] | Record<string, any>,
           options: FetchOptions<R> = {}
         ) => {
@@ -51,17 +54,17 @@ export function createClient<R extends ResponseType = "json"> (
             ...options,
             headers: {
               ...headersToObject(globalOptions.headers),
-              ...headersToObject(options.headers)
+              ...headersToObject(options.headers),
             },
-            method
+            method,
           });
         };
 
         return handler;
       },
-      apply (_target, _thisArgument, arguments_: (string | number)[] = []) {
-        return p(resolveURL(url, ...arguments_.map(index => `${index}`)));
-      }
+      apply(_target, _thisArgument, arguments_: (string | number)[] = []) {
+        return p(resolveURL(url, ...arguments_.map((index) => `${index}`)));
+      },
     });
   }
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,5 +1,4 @@
 import { resolveURL, withQuery } from 'ufo'
-import { defu } from 'defu'
 import type { QueryObject } from 'ufo'
 import { isPayloadMethod } from './utils'
 import type { FetchOptions } from './fetch'
@@ -47,9 +46,11 @@ export function createClient<R extends ResponseType = 'json'> (
             opts.body = data
           }
 
-          opts.method = method
-
-          return $fetch<T, R>(url, defu(opts, globalOptions) as FetchOptions<R>)
+          return $fetch<T, R>(url, {
+            ...(globalOptions as FetchOptions<R>),
+            ...opts,
+            method
+          })
         }
 
         return handler

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,6 +1,7 @@
 import { resolveURL, withQuery } from 'ufo'
 import { defu } from 'defu'
 import type { QueryObject } from 'ufo'
+import { isPayloadMethod } from './utils'
 import type { FetchOptions } from './fetch'
 import type { ResponseType, MappedType } from './types'
 import { $fetch } from './undici'
@@ -42,7 +43,7 @@ export function createClient<R extends ResponseType = 'json'> (
         ) => {
           if (method === 'GET' && data) {
             url = withQuery(url, data as QueryObject)
-          } else if (['POST', 'PUT', 'PATCH'].includes(method)) {
+          } else if (isPayloadMethod(method)) {
             opts.body = data
           }
 

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,6 +1,6 @@
 import { resolveURL, withQuery } from 'ufo'
 import type { QueryObject } from 'ufo'
-import { isPayloadMethod } from './utils'
+import { headersToObject, isPayloadMethod } from './utils'
 import type { FetchOptions } from './fetch'
 import type { ResponseType, MappedType } from './types'
 import { $fetch } from './undici'
@@ -49,6 +49,10 @@ export function createClient<R extends ResponseType = 'json'> (
           return $fetch<T, R>(url, {
             ...(globalOptions as FetchOptions<R>),
             ...opts,
+            headers: {
+              ...(headersToObject(globalOptions.headers) || {}),
+              ...(headersToObject(opts.headers) || {})
+            },
             method
           })
         }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,4 +1,5 @@
 import { resolveURL, withQuery } from 'ufo'
+import { defu } from 'defu'
 import type { QueryObject } from 'ufo'
 import type { FetchOptions } from './fetch'
 import type { ResponseType, MappedType } from './types'
@@ -38,7 +39,7 @@ export function createClient<R extends ResponseType = 'json'> (
 
         const handler: ClientMethodHandler = <T = any, R extends ResponseType = 'json'>(
           data?: RequestInit['body'] | Record<string, any>,
-          opts: Omit<FetchOptions<R>, 'baseURL' | 'method'> = {}
+          opts: FetchOptions<R> = {}
         ) => {
           switch (method) {
             case 'GET':
@@ -50,11 +51,9 @@ export function createClient<R extends ResponseType = 'json'> (
               opts.body = data
           }
 
-          return $fetch<T, R>(url, {
-            ...(defaults as unknown as FetchOptions<R>),
-            ...opts,
-            method
-          })
+          opts.method = method
+
+          return $fetch<T, R>(url, defu(opts, defaults) as FetchOptions<R>)
         }
 
         return handler

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -22,8 +22,7 @@ export type ClientBuilder = {
 }
 
 export function createClient<R extends ResponseType = 'json'> (
-  url: string,
-  defaults: Omit<FetchOptions<R>, 'method'> = {}
+  globalOptions: Omit<FetchOptions<R>, 'method'> = {}
 ): ClientBuilder {
   // Callable internal target required to use `apply` on it
   const internalTarget = (() => {}) as ClientBuilder
@@ -49,7 +48,7 @@ export function createClient<R extends ResponseType = 'json'> (
 
           opts.method = method
 
-          return $fetch<T, R>(url, defu(opts, defaults) as FetchOptions<R>)
+          return $fetch<T, R>(url, defu(opts, globalOptions) as FetchOptions<R>)
         }
 
         return handler
@@ -60,5 +59,5 @@ export function createClient<R extends ResponseType = 'json'> (
     })
   }
 
-  return p(url)
+  return p(globalOptions.baseURL ?? '/')
 }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -1,13 +1,13 @@
-import { resolveURL, withQuery } from 'ufo'
-import type { QueryObject } from 'ufo'
-import { headersToObject, isPayloadMethod } from './utils'
-import type { FetchOptions } from './fetch'
-import type { ResponseType, MappedType } from './types'
-import { $fetch } from './undici'
+import { resolveURL, withQuery } from "ufo";
+import type { QueryObject } from "ufo";
+import { headersToObject, isPayloadMethod } from "./utils";
+import type { FetchOptions } from "./fetch";
+import type { ResponseType, MappedType } from "./types";
+import { $fetch } from "./undici";
 
-export type ClientMethodHandler = <T = any, R extends ResponseType = 'json'>(
-  data?: RequestInit['body'] | Record<string, any>,
-  opts?: Omit<FetchOptions<R>, 'baseURL' | 'method'>
+export type ClientMethodHandler = <T = any, R extends ResponseType = "json">(
+  data?: RequestInit["body"] | Record<string, any>,
+  options?: Omit<FetchOptions<R>, "baseURL" | "method">
 ) => Promise<MappedType<R, T>>
 
 export type ClientBuilder = {
@@ -21,49 +21,49 @@ export type ClientBuilder = {
   patch: ClientMethodHandler
 }
 
-export function createClient<R extends ResponseType = 'json'> (
-  globalOptions: Omit<FetchOptions<R>, 'method'> = {}
+export function createClient<R extends ResponseType = "json"> (
+  globalOptions: Omit<FetchOptions<R>, "method"> = {}
 ): ClientBuilder {
   // Callable internal target required to use `apply` on it
-  const internalTarget = (() => {}) as ClientBuilder
+  const internalTarget = (() => {}) as ClientBuilder;
 
   function p (url: string): ClientBuilder {
     return new Proxy(internalTarget, {
       get (_target, key: string) {
-        const method = key.toUpperCase()
+        const method = key.toUpperCase();
 
-        if (!['GET', 'POST', 'PUT', 'DELETE', 'PATCH'].includes(method)) {
-          return p(resolveURL(url, key))
+        if (!["GET", "POST", "PUT", "DELETE", "PATCH"].includes(method)) {
+          return p(resolveURL(url, key));
         }
 
-        const handler: ClientMethodHandler = <T = any, R extends ResponseType = 'json'>(
-          data?: RequestInit['body'] | Record<string, any>,
-          opts: FetchOptions<R> = {}
+        const handler: ClientMethodHandler = <T = any, R extends ResponseType = "json">(
+          data?: RequestInit["body"] | Record<string, any>,
+          options: FetchOptions<R> = {}
         ) => {
-          if (method === 'GET' && data) {
-            url = withQuery(url, data as QueryObject)
+          if (method === "GET" && data) {
+            url = withQuery(url, data as QueryObject);
           } else if (isPayloadMethod(method)) {
-            opts.body = data
+            options.body = data;
           }
 
           return $fetch<T, R>(url, {
             ...(globalOptions as FetchOptions<R>),
-            ...opts,
+            ...options,
             headers: {
               ...headersToObject(globalOptions.headers || {}),
-              ...headersToObject(opts.headers || {})
+              ...headersToObject(options.headers || {})
             },
             method
-          })
-        }
+          });
+        };
 
-        return handler
+        return handler;
       },
-      apply (_target, _thisArg, args: (string | number)[] = []) {
-        return p(resolveURL(url, ...args.map(i => `${i}`)))
+      apply (_target, _thisArgument, arguments_: (string | number)[] = []) {
+        return p(resolveURL(url, ...arguments_.map(index => `${index}`)));
       }
-    })
+    });
   }
 
-  return p(globalOptions.baseURL || '/')
+  return p(globalOptions.baseURL || "/");
 }

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -5,30 +5,30 @@ import type { FetchOptions } from './fetch'
 import type { ResponseType, MappedType } from './types'
 import { $fetch } from './undici'
 
-export type ApiClientMethodHandler = <T = any, R extends ResponseType = 'json'>(
+export type ClientMethodHandler = <T = any, R extends ResponseType = 'json'>(
   data?: RequestInit['body'] | Record<string, any>,
   opts?: Omit<FetchOptions<R>, 'baseURL' | 'method'>
 ) => Promise<MappedType<R, T>>
 
-export type ApiClientBuilder = {
-  [key: string]: ApiClientBuilder;
-  (...segmentsOrIds: (string | number)[]): ApiClientBuilder
+export type ClientBuilder = {
+  [key: string]: ClientBuilder;
+  (...segmentsOrIds: (string | number)[]): ClientBuilder
 } & {
-  get: ApiClientMethodHandler
-  post: ApiClientMethodHandler
-  put: ApiClientMethodHandler
-  delete: ApiClientMethodHandler
-  patch: ApiClientMethodHandler
+  get: ClientMethodHandler
+  post: ClientMethodHandler
+  put: ClientMethodHandler
+  delete: ClientMethodHandler
+  patch: ClientMethodHandler
 }
 
 export function createClient<R extends ResponseType = 'json'> (
   url: string,
   defaults: Omit<FetchOptions<R>, 'method'> = {}
-): ApiClientBuilder {
+): ClientBuilder {
   // Callable internal target required to use `apply` on it
-  const internalTarget = (() => {}) as ApiClientBuilder
+  const internalTarget = (() => {}) as ClientBuilder
 
-  const p = (url: string): ApiClientBuilder =>
+  const p = (url: string): ClientBuilder =>
     new Proxy(internalTarget, {
       get (_target, key: string) {
         const method = key.toUpperCase()
@@ -37,7 +37,7 @@ export function createClient<R extends ResponseType = 'json'> (
           return p(resolveURL(url, key))
         }
 
-        const handler: ApiClientMethodHandler = <T = any, R extends ResponseType = 'json'>(
+        const handler: ClientMethodHandler = <T = any, R extends ResponseType = 'json'>(
           data?: RequestInit['body'] | Record<string, any>,
           opts: FetchOptions<R> = {}
         ) => {

--- a/src/builder.ts
+++ b/src/builder.ts
@@ -28,8 +28,8 @@ export function createClient<R extends ResponseType = 'json'> (
   // Callable internal target required to use `apply` on it
   const internalTarget = (() => {}) as ClientBuilder
 
-  const p = (url: string): ClientBuilder =>
-    new Proxy(internalTarget, {
+  function p (url: string): ClientBuilder {
+    return new Proxy(internalTarget, {
       get (_target, key: string) {
         const method = key.toUpperCase()
 
@@ -43,7 +43,9 @@ export function createClient<R extends ResponseType = 'json'> (
         ) => {
           switch (method) {
             case 'GET':
-              if (data) { url = withQuery(url, data as QueryObject) }
+              if (data) {
+                url = withQuery(url, data as QueryObject)
+              }
               break
             case 'POST':
             case 'PUT':
@@ -62,6 +64,7 @@ export function createClient<R extends ResponseType = 'json'> (
         return p(resolveURL(url, ...args.map(i => `${i}`)))
       }
     })
+  }
 
   return p(url)
 }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,8 +1,20 @@
 import destr from "destr";
 import { withBase, withQuery } from "ufo";
 import { createFetchError } from "./error";
-import { isPayloadMethod, isJSONSerializable, detectResponseType } from "./utils";
-import type { Fetch, RequestInfo, RequestInit, Response, ResponseType, MappedType } from "./types";
+import {
+  isPayloadMethod,
+  isJSONSerializable,
+  detectResponseType,
+  mergeFetchOptions,
+} from "./utils";
+import type {
+  Fetch,
+  RequestInfo,
+  RequestInit,
+  Response,
+  ResponseType,
+  MappedType,
+} from "./types";
 
 export interface CreateFetchOptions {
   // eslint-disable-next-line no-use-before-define

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,8 +1,8 @@
-import destr from 'destr'
-import { withBase, withQuery } from 'ufo'
-import { createFetchError } from './error'
-import { isPayloadMethod, isJSONSerializable, detectResponseType } from './utils'
-import type { Fetch, RequestInfo, RequestInit, Response, ResponseType, MappedType } from './types'
+import destr from "destr";
+import { withBase, withQuery } from "ufo";
+import { createFetchError } from "./error";
+import { isPayloadMethod, isJSONSerializable, detectResponseType } from "./utils";
+import type { Fetch, RequestInfo, RequestInit, Response, ResponseType, MappedType } from "./types";
 
 export interface CreateFetchOptions {
   // eslint-disable-next-line no-use-before-define

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,15 +1,8 @@
-import destr from "destr";
-import { withBase, withQuery } from "ufo";
-import type { Fetch, RequestInfo, RequestInit, Response } from "./types";
-import { createFetchError } from "./error";
-import {
-  isPayloadMethod,
-  isJSONSerializable,
-  detectResponseType,
-  ResponseType,
-  MappedType,
-  mergeFetchOptions,
-} from "./utils";
+import destr from 'destr'
+import { withBase, withQuery } from 'ufo'
+import { createFetchError } from './error'
+import { isPayloadMethod, isJSONSerializable, detectResponseType } from './utils'
+import type { Fetch, RequestInfo, RequestInit, Response, ResponseType, MappedType } from './types'
 
 export interface CreateFetchOptions {
   // eslint-disable-next-line no-use-before-define

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -114,6 +114,7 @@ export function createFetch(globalOptions: CreateFetchOptions): $Fetch {
     if (Error.captureStackTrace) {
       Error.captureStackTrace(error, $fetchRaw);
     }
+
     throw error;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,16 @@
+export interface ResponseMap {
+  blob: Blob;
+  text: string;
+  arrayBuffer: ArrayBuffer;
+  stream: ReadableStream<Uint8Array>;
+}
+
+export type ResponseType = keyof ResponseMap | "json";
+export type MappedType<
+  R extends ResponseType,
+  JsonType = any
+> = R extends keyof ResponseMap ? ResponseMap[R] : JsonType;
+
 export type Fetch = typeof globalThis.fetch;
 export type RequestInfo = globalThis.RequestInfo;
 export type RequestInit = globalThis.RequestInit;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,8 +1,9 @@
+import { FetchOptions } from "./fetch";
 import type { ResponseType } from "./types";
 
 const payloadMethods = new Set(["PATCH", "POST", "PUT", "DELETE"]);
 
-export function isPayloadMethod (method: string = "GET") {
+export function isPayloadMethod(method = "GET") {
   return payloadMethods.has(method.toUpperCase());
 }
 
@@ -96,7 +97,7 @@ export function mergeFetchOptions(
   return merged;
 }
 
-export function headersToObject (headers: HeadersInit = {}) {
+export function headersToObject(headers: HeadersInit = {}) {
   // SSR compatibility for `Headers` prototype
   if (typeof Headers !== "undefined" && headers instanceof Headers) {
     return Object.fromEntries(headers.entries());

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,10 +1,9 @@
-import type { FetchOptions } from "./fetch";
+import type { ResponseType } from './types'
 
-const payloadMethods = new Set(
-  Object.freeze(["PATCH", "POST", "PUT", "DELETE"])
-);
-export function isPayloadMethod(method = "GET") {
-  return payloadMethods.has(method.toUpperCase());
+const payloadMethods = new Set(['PATCH', 'POST', 'PUT', 'DELETE'])
+
+export function isPayloadMethod (method: string = 'GET') {
+  return payloadMethods.has(method.toUpperCase())
 }
 
 export function isJSONSerializable(value: any) {
@@ -35,19 +34,6 @@ const textTypes = new Set([
 ]);
 
 const JSON_RE = /^application\/(?:[\w!#$%&*.^`~-]*\+)?json(;.+)?$/i;
-
-export interface ResponseMap {
-  blob: Blob;
-  text: string;
-  arrayBuffer: ArrayBuffer;
-  stream: ReadableStream<Uint8Array>;
-}
-
-export type ResponseType = keyof ResponseMap | "json";
-export type MappedType<
-  R extends ResponseType,
-  JsonType = any
-> = R extends keyof ResponseMap ? ResponseMap[R] : JsonType;
 
 // This provides reasonable defaults for the correct parser based on Content-Type header.
 export function detectResponseType(_contentType = ""): ResponseType {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -95,3 +95,16 @@ export function mergeFetchOptions(
 
   return merged;
 }
+
+export function headersToObject (headers: HeadersInit = {}) {
+  // SSR compatibility for `Headers` prototype
+  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
+    return Object.fromEntries([...headers.entries()])
+  }
+
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers)
+  }
+
+  return headers as Record<string, string>
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,9 @@
-import type { ResponseType } from './types'
+import type { ResponseType } from "./types";
 
-const payloadMethods = new Set(['PATCH', 'POST', 'PUT', 'DELETE'])
+const payloadMethods = new Set(["PATCH", "POST", "PUT", "DELETE"]);
 
-export function isPayloadMethod (method: string = 'GET') {
-  return payloadMethods.has(method.toUpperCase())
+export function isPayloadMethod (method: string = "GET") {
+  return payloadMethods.has(method.toUpperCase());
 }
 
 export function isJSONSerializable(value: any) {
@@ -98,13 +98,13 @@ export function mergeFetchOptions(
 
 export function headersToObject (headers: HeadersInit = {}) {
   // SSR compatibility for `Headers` prototype
-  if (typeof Headers !== 'undefined' && headers instanceof Headers) {
-    return Object.fromEntries([...headers.entries()])
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
   }
 
   if (Array.isArray(headers)) {
-    return Object.fromEntries(headers)
+    return Object.fromEntries(headers);
   }
 
-  return headers as Record<string, string>
+  return headers as Record<string, string>;
 }

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -1,8 +1,10 @@
-import { type Listener, listen } from "listhen";
+import { listen } from "listhen";
+import type { Listener } from "listhen";
 import { getQuery } from "ufo";
 import { createApp, eventHandler, readBody, toNodeListener } from "h3";
 import { describe, beforeEach, afterEach, it, expect } from "vitest";
-import { type ClientBuilder, createClient } from "../src/builder";
+import { createClient } from "../src/builder";
+import type { ClientBuilder } from "../src/builder";
 
 // Test TypeScript support
 interface TypedGetResponse {

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -1,14 +1,14 @@
 import { listen } from "listhen";
-import type { Listener } from "listhen";
 import { getQuery } from "ufo";
 import { createApp, eventHandler, readBody, toNodeListener } from "h3";
 import { describe, beforeEach, afterEach, it, expect } from "vitest";
+import type { Listener } from "listhen";
 import { createClient } from "../src/builder";
 import type { ClientBuilder } from "../src/builder";
 
 // Test TypeScript support
 interface TypedGetResponse {
-  foo: string
+  foo: string;
 }
 
 describe("rest client", () => {
@@ -17,21 +17,33 @@ describe("rest client", () => {
 
   beforeEach(async () => {
     const app = createApp()
-      .use("/foo/1", eventHandler(() => ({ foo: "1" })))
-      .use("/foo", eventHandler(() => ({ foo: "bar" })))
-      .use("/bar", eventHandler(async event => ({
-        url: event.node.req.url,
-        body: await readBody(event),
-        headers: event.node.req.headers,
-        method: event.node.req.method
-      })))
-      .use("/params", eventHandler(request => getQuery(request.node.req.url || "")));
+      .use(
+        "/foo/1",
+        eventHandler(() => ({ foo: "1" }))
+      )
+      .use(
+        "/foo",
+        eventHandler(() => ({ foo: "bar" }))
+      )
+      .use(
+        "/bar",
+        eventHandler(async (event) => ({
+          url: event.node.req.url,
+          body: await readBody(event),
+          headers: event.node.req.headers,
+          method: event.node.req.method,
+        }))
+      )
+      .use(
+        "/params",
+        eventHandler((request) => getQuery(request.node.req.url || ""))
+      );
     listener = await listen(toNodeListener(app), { port: 3001 });
     client = createClient({
       baseURL: listener.url,
       headers: {
-        "X-Foo": "bar"
-      }
+        "X-Foo": "bar",
+      },
     });
   });
 
@@ -78,7 +90,10 @@ describe("rest client", () => {
   });
 
   it("override default options", async () => {
-    const { headers } = await client.bar.post({}, { headers: { "X-Foo": "baz" } });
+    const { headers } = await client.bar.post(
+      {},
+      { headers: { "X-Foo": "baz" } }
+    );
     expect(headers).to.include({ "x-foo": "baz" });
   });
 
@@ -98,10 +113,12 @@ describe("rest client", () => {
   });
 
   it("invalid api endpoint", () => {
-    expect(invalidHandle()).rejects.toThrow(/404 Not Found/);
+    expect(invalidHandle()).rejects.toThrow(
+      /404 Cannot find any route matching \/baz/
+    );
   });
 
-  async function invalidHandle () {
+  async function invalidHandle() {
     await client.baz.get<TypedGetResponse>();
   }
 });

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -1,0 +1,88 @@
+import { type Listener, listen } from 'listhen'
+import { getQuery } from 'ufo'
+import { createApp, useBody } from 'h3'
+import { describe, beforeEach, afterEach, it, expect } from 'vitest'
+import { type ClientBuilder, createClient } from '../src/builder'
+
+// Test TypeScript support
+interface TypedResponse {
+  foo: string
+}
+
+describe('rest client', () => {
+  let listener: Listener
+  let client: ClientBuilder
+
+  beforeEach(async () => {
+    const app = createApp()
+      .use('/foo/1', () => ({ foo: '1' }))
+      .use('/foo', () => ({ foo: 'bar' }))
+      .use('/bar', async req => ({
+        url: req.url,
+        body: await useBody(req),
+        headers: req.headers,
+        method: req.method
+      }))
+      .use('/params', req => getQuery(req.url || ''))
+    listener = await listen(app, { port: 3001 })
+    client = createClient(listener.url)
+  })
+
+  afterEach(async () => {
+    await listener.close()
+  })
+
+  it('GET request', async () => {
+    const response = await client.foo.get<TypedResponse>()
+    expect(response).to.deep.equal({ foo: 'bar' })
+  })
+
+  it('POST request', async () => {
+    const response = await client.bar.post({ foo: 'bar' })
+    expect(response.body).to.deep.equal({ foo: 'bar' })
+    expect(response.method).to.equal('POST')
+  })
+
+  it('PUT request', async () => {
+    const response = await client.bar.put({ foo: 'bar' })
+    expect(response.body).to.deep.equal({ foo: 'bar' })
+    expect(response.method).to.equal('PUT')
+  })
+
+  it('DELETE request', async () => {
+    const response = await client.bar.delete()
+    expect(response.method).to.equal('DELETE')
+  })
+
+  it('PATCH request', async () => {
+    const response = await client.bar.patch({ foo: 'bar' })
+    expect(response.body).to.deep.equal({ foo: 'bar' })
+    expect(response.method).to.equal('PATCH')
+  })
+
+  it('Query parameter', async () => {
+    const response = await client.params.get({ test: 'true' })
+    expect(response).to.deep.equal({ test: 'true' })
+  })
+
+  it('Bracket syntax for path segment', async () => {
+    const response = await client.foo['1'].get<TypedResponse>()
+    expect(response).to.deep.equal({ foo: '1' })
+  })
+
+  it('Chain syntax for path segment', async () => {
+    const response = await client.foo(1).get<TypedResponse>()
+    expect(response).to.deep.equal({ foo: '1' })
+  })
+
+  it('Multiple path segments', async () => {
+    const response = await client('foo', '1').get<TypedResponse>()
+    expect(response).to.deep.equal({ foo: '1' })
+  })
+
+  it('Invalid api endpoint', async () => {
+    await client.baz.get<TypedResponse>().catch((e) => {
+      expect(e.message).toMatch(/404 Not Found/)
+    })
+  })
+})

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -2,7 +2,7 @@ import { type Listener, listen } from 'listhen'
 import { getQuery } from 'ufo'
 import { createApp, useBody } from 'h3'
 import { describe, beforeEach, afterEach, it, expect } from 'vitest'
-import { type ApiClientBuilder, createClient } from '../src/builder'
+import { type ClientBuilder, createClient } from '../src/builder'
 
 // Test TypeScript support
 interface TypedGetResponse {
@@ -11,7 +11,7 @@ interface TypedGetResponse {
 
 describe('rest client', () => {
   let listener: Listener
-  let client: ApiClientBuilder
+  let client: ClientBuilder
 
   beforeEach(async () => {
     const app = createApp()

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -25,7 +25,8 @@ describe('rest client', () => {
       }))
       .use('/params', req => getQuery(req.url || ''))
     listener = await listen(app, { port: 3001 })
-    client = createClient(listener.url, {
+    client = createClient({
+      baseURL: listener.url,
       headers: {
         'X-Foo': 'bar'
       }

--- a/test/builder.test.ts
+++ b/test/builder.test.ts
@@ -1,102 +1,102 @@
-import { type Listener, listen } from 'listhen'
-import { getQuery } from 'ufo'
-import { createApp, useBody } from 'h3'
-import { describe, beforeEach, afterEach, it, expect } from 'vitest'
-import { type ClientBuilder, createClient } from '../src/builder'
+import { type Listener, listen } from "listhen";
+import { getQuery } from "ufo";
+import { createApp, useBody } from "h3";
+import { describe, beforeEach, afterEach, it, expect } from "vitest";
+import { type ClientBuilder, createClient } from "../src/builder";
 
 // Test TypeScript support
 interface TypedGetResponse {
   foo: string
 }
 
-describe('rest client', () => {
-  let listener: Listener
-  let client: ClientBuilder
+describe("rest client", () => {
+  let listener: Listener;
+  let client: ClientBuilder;
 
   beforeEach(async () => {
     const app = createApp()
-      .use('/foo/1', () => ({ foo: '1' }))
-      .use('/foo', () => ({ foo: 'bar' }))
-      .use('/bar', async req => ({
-        url: req.url,
-        body: await useBody(req),
-        headers: req.headers,
-        method: req.method
+      .use("/foo/1", () => ({ foo: "1" }))
+      .use("/foo", () => ({ foo: "bar" }))
+      .use("/bar", async request => ({
+        url: request.url,
+        body: await useBody(request),
+        headers: request.headers,
+        method: request.method
       }))
-      .use('/params', req => getQuery(req.url || ''))
-    listener = await listen(app, { port: 3001 })
+      .use("/params", request => getQuery(request.url || ""));
+    listener = await listen(app, { port: 3001 });
     client = createClient({
       baseURL: listener.url,
       headers: {
-        'X-Foo': 'bar'
+        "X-Foo": "bar"
       }
-    })
-  })
+    });
+  });
 
   afterEach(async () => {
-    await listener.close()
-  })
+    await listener.close();
+  });
 
-  it('GET request', async () => {
-    const response = await client.foo.get()
-    expect(response).to.deep.equal({ foo: 'bar' })
-  })
+  it("GET request", async () => {
+    const response = await client.foo.get();
+    expect(response).to.deep.equal({ foo: "bar" });
+  });
 
-  it('POST request', async () => {
-    const response = await client.bar.post({ foo: 'bar' })
-    expect(response.body).to.deep.equal({ foo: 'bar' })
-    expect(response.method).to.equal('POST')
-  })
+  it("POST request", async () => {
+    const response = await client.bar.post({ foo: "bar" });
+    expect(response.body).to.deep.equal({ foo: "bar" });
+    expect(response.method).to.equal("POST");
+  });
 
-  it('PUT request', async () => {
-    const response = await client.bar.put({ foo: 'bar' })
-    expect(response.body).to.deep.equal({ foo: 'bar' })
-    expect(response.method).to.equal('PUT')
-  })
+  it("PUT request", async () => {
+    const response = await client.bar.put({ foo: "bar" });
+    expect(response.body).to.deep.equal({ foo: "bar" });
+    expect(response.method).to.equal("PUT");
+  });
 
-  it('DELETE request', async () => {
-    const response = await client.bar.delete()
-    expect(response.method).to.equal('DELETE')
-  })
+  it("DELETE request", async () => {
+    const response = await client.bar.delete();
+    expect(response.method).to.equal("DELETE");
+  });
 
-  it('PATCH request', async () => {
-    const response = await client.bar.patch({ foo: 'bar' })
-    expect(response.body).to.deep.equal({ foo: 'bar' })
-    expect(response.method).to.equal('PATCH')
-  })
+  it("PATCH request", async () => {
+    const response = await client.bar.patch({ foo: "bar" });
+    expect(response.body).to.deep.equal({ foo: "bar" });
+    expect(response.method).to.equal("PATCH");
+  });
 
-  it('query parameter', async () => {
-    const response = await client.params.get({ test: 'true' })
-    expect(response).to.deep.equal({ test: 'true' })
-  })
+  it("query parameter", async () => {
+    const response = await client.params.get({ test: "true" });
+    expect(response).to.deep.equal({ test: "true" });
+  });
 
-  it('default options', async () => {
-    const { headers } = await client.bar.post()
-    expect(headers).to.include({ 'x-foo': 'bar' })
-  })
+  it("default options", async () => {
+    const { headers } = await client.bar.post();
+    expect(headers).to.include({ "x-foo": "bar" });
+  });
 
-  it('override default options', async () => {
-    const { headers } = await client.bar.post({}, { headers: { 'X-Foo': 'baz' } })
-    expect(headers).to.include({ 'x-foo': 'baz' })
-  })
+  it("override default options", async () => {
+    const { headers } = await client.bar.post({}, { headers: { "X-Foo": "baz" } });
+    expect(headers).to.include({ "x-foo": "baz" });
+  });
 
-  it('bracket syntax for path segment', async () => {
-    const response = await client.foo['1'].get<TypedGetResponse>()
-    expect(response).to.deep.equal({ foo: '1' })
-  })
+  it("bracket syntax for path segment", async () => {
+    const response = await client.foo["1"].get<TypedGetResponse>();
+    expect(response).to.deep.equal({ foo: "1" });
+  });
 
-  it('chain syntax for path segment', async () => {
-    const response = await client.foo(1).get<TypedGetResponse>()
-    expect(response).to.deep.equal({ foo: '1' })
-  })
+  it("chain syntax for path segment", async () => {
+    const response = await client.foo(1).get<TypedGetResponse>();
+    expect(response).to.deep.equal({ foo: "1" });
+  });
 
-  it('multiple path segments', async () => {
-    const response = await client('foo', '1').get<TypedGetResponse>()
-    expect(response).to.deep.equal({ foo: '1' })
-  })
+  it("multiple path segments", async () => {
+    const response = await client("foo", "1").get<TypedGetResponse>();
+    expect(response).to.deep.equal({ foo: "1" });
+  });
 
-  it('invalid api endpoint', async () => {
-    const err = await client.baz.get<TypedGetResponse>().catch(err => err)
-    expect(err.message).to.contain('404 Not Found')
-  })
-})
+  it("invalid api endpoint", async () => {
+    const error = await client.baz.get<TypedGetResponse>().catch(error_ => error_);
+    expect(error.message).to.contain("404 Not Found");
+  });
+});

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,21 +1,15 @@
-import { listen } from "listhen";
-import { getQuery, joinURL } from "ufo";
-import {
-  createApp,
-  createError,
-  eventHandler,
-  readBody,
-  readRawBody,
-  toNodeListener,
-} from "h3";
-import { Blob } from "fetch-blob";
-import { FormData } from "formdata-polyfill/esm.min.js";
-import { describe, beforeAll, afterAll, it, expect } from "vitest";
-import { Headers, $fetch } from "../src/node";
+import { listen } from 'listhen'
+import { getQuery, joinURL } from 'ufo'
+import { createApp, useBody, useRawBody } from 'h3'
+import { Blob } from 'fetch-blob'
+import { FormData } from 'formdata-polyfill/esm.min.js'
+import { describe, beforeEach, afterEach, it, expect } from 'vitest'
+import { Headers, $fetch } from '../src/node'
+import type { Listener } from 'listhen'
 
-describe("ofetch", () => {
-  let listener;
-  const getURL = (url) => joinURL(listener.url, url);
+describe('ofetch', () => {
+  let listener: Listener
+  const getURL = (url: string) => joinURL(listener.url, url)
 
   beforeAll(async () => {
     const app = createApp()

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -119,7 +119,7 @@ describe("ofetch", () => {
     ).body;
     expect(body2).to.deep.eq([{ num: 42 }, { num: 43 }]);
 
-    const headerFetches = [
+    const headerFetches: HeadersInit[] = [
       [["X-header", "1"]],
       { "x-header": "1" },
       new Headers({ "x-header": "1" }),

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -7,9 +7,9 @@ import { describe, beforeEach, afterEach, it, expect } from 'vitest'
 import { Headers, $fetch } from '../src/node'
 import type { Listener } from 'listhen'
 
-describe('ofetch', () => {
-  let listener: Listener
-  const getURL = (url: string) => joinURL(listener.url, url)
+describe("ofetch", () => {
+  let listener: Listener;
+  const getURL = (url: string) => joinURL(listener.url, url);
 
   beforeAll(async () => {
     const app = createApp()

--- a/test/fetch.test.ts
+++ b/test/fetch.test.ts
@@ -1,11 +1,18 @@
-import { listen } from 'listhen'
-import { getQuery, joinURL } from 'ufo'
-import { createApp, useBody, useRawBody } from 'h3'
-import { Blob } from 'fetch-blob'
-import { FormData } from 'formdata-polyfill/esm.min.js'
-import { describe, beforeEach, afterEach, it, expect } from 'vitest'
-import { Headers, $fetch } from '../src/node'
-import type { Listener } from 'listhen'
+import { listen } from "listhen";
+import { getQuery, joinURL } from "ufo";
+import {
+  createApp,
+  createError,
+  eventHandler,
+  readBody,
+  readRawBody,
+  toNodeListener,
+} from "h3";
+import { Blob } from "fetch-blob";
+import { FormData } from "formdata-polyfill/esm.min.js";
+import { describe, beforeAll, it, expect, afterAll } from "vitest";
+import type { Listener } from "listhen";
+import { Headers, $fetch } from "../src/node";
 
 describe("ofetch", () => {
   let listener: Listener;


### PR DESCRIPTION
Hi there, @pi0, so here it is as discussed!

## Minimal, Type-Safe REST Client

[`unrested`](https://github.com/johannschopplich/unrested) is now part of `ofetch` and has been cleaned up internally. Test coverage has been increased as well and updated to use `listhen` just like the tests for `$fetch`.

This package now ships with `createClient`, a tiny REST client built upon JS proxies. It re-uses every UnJS gem, like `ufo` and `defu`.

The [documentation has been added](https://github.com/johannschopplich/ohmyfetch/tree/feat/rest-client#-rest-client-with-createclient) as well.

I hope this PR looks good to you. If I missed something, let me know. Thanks!

## Notes

- ~~I removed `@types/node-fetch` from this repo. `node-fetch` provides its own type definitions, so we don't need this installed.~~ Already done upstream.
- The build config's option `emitCJS: false` is deprecated in the latest `unbuild` version. The package's `exports` declare CJS build artifacts, so I enabled them again. 
- Some minor refactorings have been applied to the code base.
- Heading capitalization of the main README has been made consistent.

## Features

You can use `ofetch` as a minimal, type-safe REST client for any given API. The API builder uses JS proxies under the hood.

```js
import { createClient } from 'ofetch'

const api = createClient({
  // Set optional defaults for `$fetch`
  baseURL: '<baseURL>'
})
```

The `baseURL` will default to `/` if not set.

### Path Segment Chaining

Chain single path segments or path ids by a dot. You can even type the response of your request!

```js
// GET request to <baseURL>/users
const users = await api.users.get<UserResponse>()

// For GET request you can add search params
// <baseURL>/users?search=john
const users = await api.users.get<UserResponse>({ search: 'john' })

// Chains can get as deep as you wish
// <baseURL>/deeply/nested
const data = await api.deeply.nested.get()
```

To include dynamic API path segments, you have two options:

```js
// Typed GET request to <baseURL>/users/1
const userId = 1
// … using the chain syntax:
const user = await api.users(userId).get<UserResponse>()
// … or the bracket syntax:
const user = await api.users[`${userId}`].get<UserResponse>()
```

### HTTP Request Methods

Add the appropriate method to the end of your API call. The following methods are supported:

- `get()`
- `post()`
- `put()`
- `delete()`
- `patch()`

### Payload Requests

For HTTP request methods supporting a payload, add it to the method call:

```js
// POST request to <baseURL>/users
const response = await api.users.post({ name: 'foo' })
```

### Overwrite Default Options

You can add/overwrite `$fetch` options on a method-level as well:

```js
const response = await api.users.get({
  headers: {
    'Cache-Control': 'no-cache'
  }
})
```