### PR TITLE
fix: improve error message for request errors

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -13,11 +13,11 @@ export class FetchError<T = any> extends Error {
 
 export function createFetchError<T = any> (request: FetchRequest, error?: Error, response?: FetchResponse<T>): FetchError<T> {
   let message = "";
-  if (request && response) {
-    message = `${response.status} ${response.statusText} (${request.toString()})`;
-  }
   if (error) {
-    message = `${error.message} (${message})`;
+    message = error.message;
+  }
+  if (request && response) {
+    message = `${message} (${response.status} ${response.statusText} (${request.toString()}))`;
   }
 
   const fetchError: FetchError<T> = new FetchError(message);

--- a/src/error.ts
+++ b/src/error.ts
@@ -18,6 +18,8 @@ export function createFetchError<T = any> (request: FetchRequest, error?: Error,
   }
   if (request && response) {
     message = `${message} (${response.status} ${response.statusText} (${request.toString()}))`;
+  } else if (request) {
+    message = `${message} (${request.toString()})`;
   }
 
   const fetchError: FetchError<T> = new FetchError(message);


### PR DESCRIPTION
The error message itself looks erroneous when the fetch fails without any request or response. Usually a network error. This can happen when a user disconnects from the internet or a fetch endpoint has an invalid ssl certfiicate.

Previously the message would be `Failed to Fetch ()` with these empty brackets.

Simple refactor to build the message up in the order that the final string will be and include the brackets only if required.

Thanks for all your work on this project! It's great.