### PR TITLE
fix: avoid parsing empty body

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -144,7 +144,7 @@ export function createFetch (globalOptions: CreateFetchOptions): $Fetch {
     const isZeroContentLength = !context.response.headers.get("content-length") || context.response.headers.get("content-length") === "0";
     const isResponseBodyEmpty = isInformationStatusCode || isNoContentStatusCode || isNotModifiedStatusCode || isZeroContentLength;
 
-    if (isResponseBodyEmpty) {
+    if (!isResponseBodyEmpty) {
       const responseType =
         (context.options.parseResponse ? "json" : context.options.responseType) ||
         detectResponseType(context.response.headers.get("content-type") || "");

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,6 @@
 import { listen } from "listhen";
 import { getQuery, joinURL } from "ufo";
-import { createApp, eventHandler, readBody, readRawBody, toNodeListener } from "h3";
+import { createApp, eventHandler, readBody, readRawBody, toNodeListener, send, appendResponseHeader } from "h3";
 import { Blob } from "fetch-blob";
 import { FormData } from "formdata-polyfill/esm.min.js";
 import { describe, beforeEach, afterEach, it, expect } from "vitest";
@@ -21,6 +21,30 @@ describe("ofetch", () => {
         return new Blob(["binary"]);
       }))
       .use("/echo", eventHandler(async event => ({ body: await readRawBody(event) })));
+      // .use("/1xx", eventHandler((event) => {
+      //   // TODO: replace with `h3.sendNoContent()`
+      //   event.node.res.statusCode = 100;
+      //   event.node.res.removeHeader("content-length");
+      //   send(event);
+      // }))
+      // .use("/204", eventHandler((event) => {
+      //   // TODO: replace with `h3.sendNoContent()`
+      //   event.node.res.statusCode = 204;
+      //   event.node.res.removeHeader("content-length");
+      //   send(event);
+      // }))
+      // .use("/304", eventHandler((event) => {
+      //   event.node.res.statusCode = 304;
+      //   send(event);
+      // }))
+      // .use("/no-content-length", eventHandler((event) => {
+      //   send(event, JSON.stringify({ key: "value" }), "application/json");
+      // }))
+      // .use("/zero-content-length", eventHandler((event) => {
+      //   appendResponseHeader(event, "Content-Length", "0");
+      //   send(event, JSON.stringify({ key: "value" }), "application/json");
+      // }));
+
     listener = await listen(toNodeListener(app));
   });
 
@@ -29,6 +53,7 @@ describe("ofetch", () => {
   });
 
   it("ok", async () => {
+    console.log(await $fetch(getURL("ok")));
     expect(await $fetch(getURL("ok"))).to.equal("ok");
   });
 
@@ -48,6 +73,14 @@ describe("ofetch", () => {
 
   it("returns a blob for binary content-type", async () => {
     expect(await $fetch(getURL("binary"))).to.be.instanceOf(Blob);
+  });
+
+  it("avoid parsing response when the body is empty", async () => {
+    expect(await $fetch(getURL("1xx"))).to.be.instanceOf(Blob);
+    expect(await $fetch(getURL("204"))).to.be.instanceOf(Blob);
+    expect(await $fetch(getURL("304"), { method: "POST" })).to.be.instanceOf(Blob);
+    expect(await $fetch(getURL("no-content-length"))).to.be.instanceOf(Blob);
+    expect(await $fetch(getURL("zero-content-length"))).to.be.instanceOf(Blob);
   });
 
   it("baseURL", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -25,17 +25,17 @@ describe("ofetch", () => {
         // TODO: replace with `h3.sendNoContent()`
         event.node.res.statusCode = 100;
         event.node.res.removeHeader("content-length");
-        send(event);
+        event.node.res.end();
       }))
       .use("/204", eventHandler((event) => {
         // TODO: replace with `h3.sendNoContent()`
         event.node.res.statusCode = 204;
         event.node.res.removeHeader("content-length");
-        send(event);
+        event.node.res.end();
       }))
       .use("/304", eventHandler((event) => {
         event.node.res.statusCode = 304;
-        send(event);
+        event.node.res.end();
       }))
       .use("/no-content-length", eventHandler((event) => {
         send(event, JSON.stringify({ key: "value" }), "application/json");


### PR DESCRIPTION
Resolves #171.

Still WIP, bug included.

---

In addition, unrelated part of unit test fails even at the latest commit of `main` branch, so this should be fixed first.

```
 FAIL  test/index.test.ts > ofetch > Bypass FormData body
AssertionError: the given combination of arguments (undefined and string) is invalid for this assertion. You can use an array, a map, an object, a set, a string, or a weakset instead of a string
 ❯ test/index.test.ts:134:21
    132|     data.append("foo", "bar");
    133|     const { body } = await $fetch(getURL("post"), { method: "POST", body: data });
    134|     expect(body).to.include("form-data; name=\"foo\"");
       |                     ^
    135|   });
    136|
```