### PR TITLE
fix: fix exports for node

### DIFF
--- a/cjs/index.cjs
+++ b/cjs/index.cjs
@@ -2,7 +2,13 @@ const getExport = name => import("../dist/index.mjs").then(r => r[name]);
 const createCaller = name => (input, init) => getExport(name).then(function_ => function_(input, init));
 
 exports.fetch = createCaller("fetch");
+
 exports.ofetch = createCaller("ofetch");
+exports.ofetch.create = defaultOptions => getExport("ofetch").then($fetch => $fetch.create(defaultOptions));
+exports.ofetch.raw = (input, init) => getExport("ofetch").then($fetch => $fetch.raw(input, init));
+exports.ofetch.native = (input, init) => getExport("ofetch").then($fetch => $fetch.native(input, init));
+
 exports.$fetch = createCaller("$fetch");
+exports.$fetch.create = defaultOptions => getExport("$fetch").then($fetch => $fetch.create(defaultOptions));
 exports.$fetch.raw = (input, init) => getExport("$fetch").then($fetch => $fetch.raw(input, init));
 exports.$fetch.native = (input, init) => getExport("$fetch").then($fetch => $fetch.native(input, init));

--- a/cjs/node.cjs
+++ b/cjs/node.cjs
@@ -2,7 +2,13 @@ const getExport = name => import("../dist/node.mjs").then(r => r[name]);
 const createCaller = name => (input, init) => getExport(name).then(function_ => function_(input, init));
 
 exports.fetch = createCaller("fetch");
+
 exports.ofetch = createCaller("ofetch");
+exports.ofetch.create = defaultOptions => getExport("ofetch").then($fetch => $fetch.create(defaultOptions));
+exports.ofetch.raw = (input, init) => getExport("ofetch").then($fetch => $fetch.raw(input, init));
+exports.ofetch.native = (input, init) => getExport("ofetch").then($fetch => $fetch.native(input, init));
+
 exports.$fetch = createCaller("$fetch");
+exports.$fetch.create = defaultOptions => getExport("$fetch").then($fetch => $fetch.create(defaultOptions));
 exports.$fetch.raw = (input, init) => getExport("$fetch").then($fetch => $fetch.raw(input, init));
 exports.$fetch.native = (input, init) => getExport("$fetch").then($fetch => $fetch.native(input, init));


### PR DESCRIPTION
Resolves #198 

I tested this PR in the following way:

- Copy files from Stackblitz reproduction link to my local (https://github.com/unjs/ofetch/issues/198#issuecomment-1404207449)
- Modify `node_modules` as this PR
- Confirm the bug is fixed in my local in 3 ways:
  - With `require('ofetch')` (from  `exports["."]["node"]["require"]` in `package.json`
  - With `require('ofetch')` (from  `exports["default"]["require"]` in `package.json` (with `.` subpath deleted in the file for fallback to work)
  - With `require('ofetch/node')` (from  `exports["./node"]["require"]` in `package.json`