### PR TITLE
build: use standalone commonjs dist

### DIFF
--- a/cjs/index.cjs
+++ b/cjs/index.cjs
@@ -1,8 +1,0 @@
-const getExport = name => import("../dist/index.mjs").then(r => r[name]);
-const createCaller = name => (input, init) => getExport(name).then(function_ => function_(input, init));
-
-exports.fetch = createCaller("fetch");
-exports.ofetch = createCaller("ofetch");
-exports.$fetch = createCaller("$fetch");
-exports.$fetch.raw = (input, init) => getExport("$fetch").then($fetch => $fetch.raw(input, init));
-exports.$fetch.native = (input, init) => getExport("$fetch").then($fetch => $fetch.native(input, init));

--- a/cjs/node.cjs
+++ b/cjs/node.cjs
@@ -1,8 +1,0 @@
-const getExport = name => import("../dist/node.mjs").then(r => r[name]);
-const createCaller = name => (input, init) => getExport(name).then(function_ => function_(input, init));
-
-exports.fetch = createCaller("fetch");
-exports.ofetch = createCaller("ofetch");
-exports.$fetch = createCaller("$fetch");
-exports.$fetch.raw = (input, init) => getExport("$fetch").then($fetch => $fetch.raw(input, init));
-exports.$fetch.native = (input, init) => getExport("$fetch").then($fetch => $fetch.native(input, init));

--- a/package.json
+++ b/package.json
@@ -11,21 +11,21 @@
       "node": {
         "types": "./dist/node.d.ts",
         "import": "./dist/node.mjs",
-        "require": "./cjs/node.cjs"
+        "require": "./dist/node.cjs"
       },
       "default": {
         "types": "./dist/index.d.ts",
         "import": "./dist/index.mjs",
-        "require": "./cjs/index.cjs"
+        "require": "./dist/index.cjs"
       }
     },
     "./node": {
       "types": "./dist/node.d.ts",
       "import": "./dist/node.mjs",
-      "require": "./cjs/node.cjs"
+      "require": "./dist/node.cjs"
     }
   },
-  "main": "./cjs/node.cjs",
+  "main": "./dist/node.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "files": [

--- a/package.json
+++ b/package.json
@@ -30,8 +30,7 @@
   "types": "./dist/index.d.ts",
   "files": [
     "dist",
-    "node.d.ts",
-    "cjs"
+    "node.d.ts"
   ],
   "scripts": {
     "build": "unbuild",


### PR DESCRIPTION
Resolves #198
Resolves #44

Thanks to [node-fetch-native](https://github.com/unjs/node-fetch-native), we can have standalone CJS build without dist mocks