### PR TITLE
feat: allow sanitization using ufo

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -96,6 +96,12 @@ describe("ofetch", () => {
     );
   });
 
+  it("ufoSanitization", async () => {
+    expect(await $fetch("/x", { baseURL: getURL("url"), sanitization: ['withTrailingSlash'] })).to.equal(
+      "/x/"
+    );
+  });
+
   it("stringifies posts body automatically", async () => {
     const { body } = await $fetch(getURL("post"), {
       method: "POST",


### PR DESCRIPTION
Motivation:

Using create fetch and composables around `$fetch` in my Nuxt app that have my baseURL, but also not necessarily adding trailing slashes from all points where it is being used which may be required by the server, and rather than providing a single `withTrailingSlash: boolean` option, given all awesome utilities `unjs/ufo` provides, may as well make benefit of all!