### PR TITLE
feat: export `ResponseMap` type to allow composition of `ofetch`

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,7 +34,7 @@ const textTypes = new Set([
 
 const JSON_RE = /^application\/(?:[\w!#$%&*.^`~-]*\+)?json(;.+)?$/i;
 
-interface ResponseMap {
+export interface ResponseMap {
   blob: Blob;
   text: string;
   arrayBuffer: ArrayBuffer;


### PR DESCRIPTION
This re-exports the `ResponseMap` type. The use case for this is to allow consumers to build a type-safe variant of `ofetch` such we can append methods to a given instance.

Consider this wrapper library below called `api.ts`. In the code below, the `FetchOptions` type from `ofetch` consumes the private type `ResponseMap`. Building declarations for `api.ts` types for this would fail because the `ResponseMap` type is private to `ofetch`. In this case, re-exporting the type fixes the error and declarations can be built in userland.

```ts
// api.ts lib
import { ofetch, FetchOptions } from "ofetch";

export const $fetch = ofetch.create({
  baseURL: SOME_API_BASE_URL,
  headers: {
    Accept: "application/json",
    "Content-Type": "application/json",
  },
  onRequest(context) {
    console.log("context", context.options);
  },
  credentials: "include",
});

/**
 * HTTP API Fetch instance
 * @param request
 * @param options
 * @returns
 */
export function api<T = any, R extends ResponseType = "json">(
  request: FetchRequest,
  options?: FetchOptions<R>
): Promise<MappedType<R, T>> {
  return $fetch<T, R>(request, options) as Promise<MappedType<R, T>>;
}

/* Appends `get` Method to `api` function object */
api.get = function get<T = any, R extends ResponseType = "json">(
  url: string,
  options: Omit<FetchOptions, "method"> = {}
): Promise<MappedType<R, T>> {
  return api(url, {
    ...options,
    method: "GET",
  });
};
```