### PR TITLE
fix: pass empty object to headers initializer to prevent crash on chrome 49

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -160,7 +160,8 @@ export function createFetch(globalOptions: CreateFetchOptions): $Fetch {
 
         // Set Content-Type and Accept headers to application/json by default
         // for JSON serializable request bodies.
-        context.options.headers = new Headers(context.options.headers);
+        // Pass empty object as older browsers don't support undefined.
+        context.options.headers = new Headers(context.options.headers || {});
         if (!context.options.headers.has("content-type")) {
           context.options.headers.set("content-type", "application/json");
         }


### PR DESCRIPTION
ofetch crashes in Chrome 49 (which is the latest available Chrome on Windows XP which is still relevant in certain GovTech) with this message:

```
Failed to construct 'Headers': No matching constructor signature.
```

This is because older Chrome didn't treat `new Headers(undefined)` as `new Headers()`.

This PR fixes this inconvenience with no noticeable burden for modern browsers (or code base readability).

Related: https://github.com/whatwg/fetch/issues/185