### PR TITLE
docs(readme): use `_data` rather than `data` for raw requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ If you need to access raw response (for headers, etc), can use `ofetch.raw`:
 ```js
 const response = await ofetch.raw('/sushi')
 
-// response.data
+// response._data
 // response.headers
 // ...
 ```


### PR DESCRIPTION
Following https://github.com/unjs/ofetch/pull/49 the README should be updated accordingly.