### PR TITLE
docs: mention `DELETE` is no-retry be default

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ await ofetch(...).catch((error) => error.data)
 
 ## ✔️ Auto Retry
 
-`ofetch` Automatically retries the request if an error happens. Default is `1` (except for `POST`, `PUT` and `PATCH` methods that is `0`)
+`ofetch` Automatically retries the request if an error happens. Default is `1` (except for `POST`, `PUT`, `PATCH` and `DELETE` methods that is `0`)
 
 ```ts
 await ofetch('http://google.com/404', {


### PR DESCRIPTION
In `fetch.ts`, the `DELETE` method `retries` default also is **0**

https://github.com/unjs/ofetch/blob/9a5cd33b568ef70f476bda647cd43b1040aaa479/src/fetch.ts#L99
https://github.com/unjs/ofetch/blob/9a5cd33b568ef70f476bda647cd43b1040aaa479/src/utils.ts#L1-L6