### PR TITLE
fix: deep merge fetch options

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -130,7 +130,7 @@ export function createFetch(globalOptions: CreateFetchOptions): $Fetch {
   ) {
     const context: FetchContext = {
       request: _request,
-      options: mergeFetchOptions(globalOptions.defaults, _options, Headers),
+      options: mergeFetchOptions(_options, globalOptions.defaults, Headers),
       response: undefined,
       error: undefined,
     };

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -8,7 +8,7 @@ import {
   detectResponseType,
   ResponseType,
   MappedType,
-  deepMerge,
+  mergeFetchOptions,
 } from "./utils";
 
 export interface CreateFetchOptions {
@@ -129,7 +129,7 @@ export function createFetch(globalOptions: CreateFetchOptions): $Fetch {
   ) {
     const context: FetchContext = {
       request: _request,
-      options: deepMerge(globalOptions.defaults || {}, _options),
+      options: mergeFetchOptions(globalOptions.defaults, _options),
       response: undefined,
       error: undefined,
     };

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -8,6 +8,7 @@ import {
   detectResponseType,
   ResponseType,
   MappedType,
+  deepMerge,
 } from "./utils";
 
 export interface CreateFetchOptions {
@@ -128,7 +129,7 @@ export function createFetch(globalOptions: CreateFetchOptions): $Fetch {
   ) {
     const context: FetchContext = {
       request: _request,
-      options: { ...globalOptions.defaults, ..._options },
+      options: deepMerge(globalOptions.defaults || {}, _options),
       response: undefined,
       error: undefined,
     };

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -130,7 +130,7 @@ export function createFetch(globalOptions: CreateFetchOptions): $Fetch {
   ) {
     const context: FetchContext = {
       request: _request,
-      options: mergeFetchOptions(globalOptions.defaults, _options),
+      options: mergeFetchOptions(globalOptions.defaults, _options, Headers),
       response: undefined,
       error: undefined,
     };

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -161,7 +161,7 @@ export function createFetch(globalOptions: CreateFetchOptions): $Fetch {
 
         // Set Content-Type and Accept headers to application/json by default
         // for JSON serializable request bodies.
-        context.options.headers = new Headers(context.options.headers);
+        context.options.headers = new Headers(context.options.headers || {});
         if (!context.options.headers.has("content-type")) {
           context.options.headers.set("content-type", "application/json");
         }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,3 +1,5 @@
+import { FetchOptions } from "./fetch";
+
 const payloadMethods = new Set(
   Object.freeze(["PATCH", "POST", "PUT", "DELETE"])
 );
@@ -72,15 +74,19 @@ export function detectResponseType(_contentType = ""): ResponseType {
   return "blob";
 }
 
-// Deep merging of objects,
-export function deepMerge(obj1: Record<string, any>, obj2: Record<string, any>): Record<string, any> {
-  const merged = { ...obj1, ...obj2 };
+// Merging of fetch option objects.
+export function mergeFetchOptions(obj1: FetchOptions | undefined, obj2: FetchOptions | undefined): Record<string, any> {
+  const merged = Object.assign({}, obj1, obj2);
 
-  for (const key of Object.keys(merged)) {
-    // Recursively merge any objects
-    if (typeof merged[key] === "object" && merged[key] !== null) {
-      merged[key] = deepMerge(obj1[key], obj2[key]);
-    }
+  // Merge special cases deeper.
+  if (obj1?.headers && obj2?.headers) {
+    merged.headers = Object.assign({}, obj1.headers, obj2.headers);
+  }
+  if (obj1?.params && obj2?.params) {
+    merged.params = Object.assign({}, obj1?.params, obj2?.params);
+  }
+  if (obj1?.query && obj2?.query) {
+    merged.query = Object.assign({}, obj1?.query, obj2?.query);
   }
 
   return merged;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -71,3 +71,17 @@ export function detectResponseType(_contentType = ""): ResponseType {
 
   return "blob";
 }
+
+// Deep merging of objects,
+export function deepMerge(obj1: Record<string, any>, obj2: Record<string, any>): Record<string, any> {
+  const merged = { ...obj1, ...obj2 };
+
+  for (const key of Object.keys(merged)) {
+    // Recursively merge any objects
+    if (typeof merged[key] === "object" && merged[key] !== null) {
+      merged[key] = deepMerge(obj1[key], obj2[key]);
+    }
+  }
+
+  return merged;
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -77,7 +77,8 @@ export function detectResponseType(_contentType = ""): ResponseType {
 // Merging of fetch option objects.
 export function mergeFetchOptions(
   obj1: FetchOptions | undefined,
-  obj2: FetchOptions | undefined
+  obj2: FetchOptions | undefined,
+  Headers = globalThis.Headers
 ): Record<string, any> {
   const merged = Object.assign({}, obj1, obj2);
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -86,18 +86,25 @@ export function mergeFetchOptions(
   };
 
   // Merge params and query
-  merged.query = {
-    ...defaults?.params,
-    ...defaults?.query,
-    ...input?.params,
-    ...input?.query,
-  };
-  delete merged.params;
+  if (defaults?.params && input?.params) {
+    merged.params = {
+      ...defaults?.params,
+      ...input?.params,
+    };
+  }
+  if (defaults?.query && input?.query) {
+    merged.query = {
+      ...defaults?.query,
+      ...input?.query,
+    };
+  }
 
   // Merge headers
-  merged.headers = new Headers(defaults?.headers || {});
-  for (const [key, value] of new Headers(input?.headers || {})) {
-    merged.headers.set(key, value);
+  if (defaults?.headers && input?.headers) {
+    merged.headers = new Headers(defaults?.headers || {});
+    for (const [key, value] of new Headers(input?.headers || {})) {
+      merged.headers.set(key, value);
+    }
   }
 
   return merged;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,8 +79,8 @@ export function mergeFetchOptions(
   input: FetchOptions | undefined,
   defaults: FetchOptions | undefined,
   Headers = globalThis.Headers
-): Record<string, any> {
-  const merged = {
+): FetchOptions {
+  const merged: FetchOptions = {
     ...defaults,
     ...input,
   };

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -81,8 +81,8 @@ export function mergeFetchOptions(
   Headers = globalThis.Headers
 ): Record<string, any> {
   const merged = {
-    ...input,
     ...defaults,
+    ...input,
   };
 
   // Merge params and query

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,18 +75,31 @@ export function detectResponseType(_contentType = ""): ResponseType {
 }
 
 // Merging of fetch option objects.
-export function mergeFetchOptions(obj1: FetchOptions | undefined, obj2: FetchOptions | undefined): Record<string, any> {
+export function mergeFetchOptions(
+  obj1: FetchOptions | undefined,
+  obj2: FetchOptions | undefined
+): Record<string, any> {
   const merged = Object.assign({}, obj1, obj2);
 
   // Merge special cases deeper.
-  if (obj1?.headers && obj2?.headers) {
-    merged.headers = Object.assign({}, obj1.headers, obj2.headers);
-  }
   if (obj1?.params && obj2?.params) {
-    merged.params = Object.assign({}, obj1?.params, obj2?.params);
+    merged.params = Object.assign({}, obj1.params, obj2.params);
   }
   if (obj1?.query && obj2?.query) {
-    merged.query = Object.assign({}, obj1?.query, obj2?.query);
+    merged.query = Object.assign({}, obj1.query, obj2.query);
+  }
+
+  if (obj1?.headers && obj2?.headers) {
+    const h1 = new Headers(obj1.headers);
+    const h2 = new Headers(obj2.headers);
+    const headers = new Headers();
+    for (const [key, value] of h1.entries()) {
+      headers.set(key, value);
+    }
+    for (const [key, value] of h2.entries()) {
+      headers.set(key, value);
+    }
+    merged.headers = headers;
   }
 
   return merged;

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -206,19 +206,24 @@ describe("ofetch", () => {
   it("deep merges defaultOptions", async () => {
     const createdFetch = $fetch.create({
       headers: {
-        'Test-Header-Default': '1',
-      }
+        "x-header-a": "0",
+        "x-header-b": "2",
+      },
     });
     const { headers } = await createdFetch(getURL("post"), {
       method: "POST",
-      body: '',
+      body: "",
       headers: {
         "Content-Type": "text/plain",
-        "Test-Header-Request": "1",
-      }
+        "x-header-a": "1",
+        "x-header-c": "3",
+      },
     });
 
-    expect(headers).to.include({"test-header-default": "1"});
-    expect(headers).to.include({"test-header-request": "1"});
+    expect(headers).to.include({
+      "x-header-a": "1",
+      "x-header-b": "2",
+      "x-header-c": "3",
+    });
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -35,7 +35,10 @@ describe("ofetch", () => {
         "/echo",
         eventHandler(async (event) => ({
           path: event.path,
-          body: event.node.req.method === 'POST' ? await readRawBody(event) : undefined,
+          body:
+            event.node.req.method === "POST"
+              ? await readRawBody(event)
+              : undefined,
           headers: event.node.req.headers,
         }))
       )
@@ -240,6 +243,6 @@ describe("ofetch", () => {
       "x-header-c": "3",
     });
 
-    expect(path).to.eq('?b=2&c=3&a=1')
+    expect(path).to.eq("?b=2&c=3&a=1");
   });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -189,4 +189,23 @@ describe("ofetch", () => {
     }
     expect(abortHandle()).rejects.toThrow(/aborted/);
   });
+
+  it("deep merges defaultOptions", async () => {
+    const createdFetch = $fetch.create({
+      headers: {
+        'Test-Header-Default': '1',
+      }
+    });
+    const { headers } = await createdFetch(getURL("post"), {
+      method: "POST",
+      body: '',
+      headers: {
+        "Content-Type": "text/plain",
+        "Test-Header-Request": "1",
+      }
+    });
+
+    expect(headers).to.include({"test-header-default": "1"});
+    expect(headers).to.include({"test-header-request": "1"});
+  });
 });


### PR DESCRIPTION
**Problem**
If a fetch instance is created with default header options, and that instance is then called with more headers the default headers are overwritten. The same goes for the `param` and `query` properties.

```
const createdFetch = $fetch.create({
  headers: {
    "Header-Default": "1",
  }
});

createdFetch("/some-url", {
  headers: {
    "Header-Request": "1",
  }
});
```
The outgoing request should have both the `Header-Request` and `Header-Default` headers, but will only contain the former.

**Fix**
Merging the `headers`, `params` and `query` properties of the `FetchOptions` object before fetching fixes this issue. A more generic deep merge approach was tried, but merging other properties such as the body makes little sense.