### PR TITLE
FEAT: Support `retry` function

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -210,6 +210,40 @@ describe("ofetch", () => {
     expect(abortHandle()).rejects.toThrow(/aborted/);
   });
 
+  it("baseURL with function retry", async () => {
+    let retries = 4;
+    const error = await $fetch("", {
+      baseURL: getURL("404"),
+      retry: () => {
+        retries--;
+        return new Promise((resolve) => {
+          setTimeout(() => resolve(retries !== 0), 0);
+        });
+      },
+    }).catch((error_) => error_);
+    expect(error.request).to.equal(getURL("404"));
+  });
+
+  it("abort with function retry", () => {
+    const controller = new AbortController();
+    let retries = 4;
+    async function abortHandle() {
+      controller.abort();
+      const response = await $fetch("", {
+        baseURL: getURL("ok"),
+        retry: () => {
+          retries--;
+          return new Promise((resolve) => {
+            setTimeout(() => resolve(retries !== 0), 0);
+          });
+        },
+        signal: controller.signal,
+      });
+      console.log("response", response);
+    }
+    expect(abortHandle()).rejects.toThrow(/aborted/);
+  });
+
   it("deep merges defaultOptions", async () => {
     const _customFetch = $fetch.create({
       query: {


### PR DESCRIPTION
Hello,

ofetch and all unjs package are really awesome !

So far, `retry` option allow `number` which retry fetch until the count is 0.
This PR allow to set `retry` with a function. It can be useful to handle programmatically or delay retries, and implements any retry backoff algorithm.