### PR TITLE
fix: remove `type` field

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "repository": "unjs/ofetch",
   "license": "MIT",
   "sideEffects": false,
-  "type": "module",
   "exports": {
     "./package.json": "./package.json",
     ".": {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

close #251 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`exports` has declared which file to `require` or `import`, it's a dual-format package.

```json
{
  "exports": {
    "default": {
      "types": "./dist/index.d.ts",
      "import": "./dist/index.mjs",
      "require": "./dist/index.cjs"
    }
  }
}
```

But if `type` is `module`, it can't be imported in a commonjs file.

> The current file is a CommonJS module whose imports will produce 'require' calls; however, the referenced file is an ECMAScript module and cannot be imported with 'require'. Consider writing a dynamic 'import("ofetch")' call instead.


### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
