### PR TITLE
fix: avoid serializing body with buffer type

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,6 +21,9 @@ export function isJSONSerializable(value: any) {
   if (Array.isArray(value)) {
     return true;
   }
+  if (value.buffer) {
+    return false;
+  }
   return (
     (value.constructor && value.constructor.name === "Object") ||
     typeof value.toJSON === "function"

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -170,6 +170,16 @@ describe("ofetch", () => {
     expect(body).to.deep.eq(message);
   });
 
+  it("Handle buffer body", async () => {
+    const message = "Hallo von Pascal";
+    const { body } = await $fetch(getURL("echo"), {
+      method: "POST",
+      body: Buffer.from("Hallo von Pascal"),
+      headers: { "Content-Type": "text/plain" },
+    });
+    expect(body).to.deep.eq(message);
+  });
+
   it("Bypass FormData body", async () => {
     const data = new FormData();
     data.append("foo", "bar");


### PR DESCRIPTION
### 🔗 Linked issue

resolves #269

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Normally we allow serializing pure objects (with object constructor) OR classes that implement `toJSON()`.

However Buffer type is different and implements a `toJSON` method which is mainly for debugging.

This PR detects buffer type without depending on global `Buffer` as (Node.js) workaround 

Note: Worth to mention that other `BodyInit` compatible types such as `UInt8Array` do not share this issue as do not implement `toJSON`. We might consider detecting them explicitly if any runtime in the feature does. (-- Investigating Readable Body stream in next steps, current check currently allows it to be unserialized --)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
