### PR TITLE
fix: augment `FetchError` type to include `IFetchError`

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -17,15 +17,6 @@ export interface IFetchError<T = any> extends Error {
 }
 
 export class FetchError<T = any> extends Error implements IFetchError<T> {
-  request?: FetchRequest;
-  options?: FetchOptions;
-  response?: FetchResponse<T>;
-  data?: T;
-  status?: number;
-  statusText?: string;
-  statusCode?: number;
-  statusMessage?: string;
-
   constructor(message: string, opts?: { cause: unknown }) {
     // @ts-ignore https://v8.dev/features/error-cause
     super(message, opts);
@@ -38,6 +29,9 @@ export class FetchError<T = any> extends Error implements IFetchError<T> {
     }
   }
 }
+
+// Augment `FetchError` type to include `IFetchError` properties
+export interface FetchError<T = any> extends IFetchError<T> {}
 
 export function createFetchError<T = any>(
   ctx: FetchContext<T>

--- a/src/error.ts
+++ b/src/error.ts
@@ -17,6 +17,15 @@ export interface IFetchError<T = any> extends Error {
 }
 
 export class FetchError<T = any> extends Error implements IFetchError<T> {
+  request?: FetchRequest;
+  options?: FetchOptions;
+  response?: FetchResponse<T>;
+  data?: T;
+  status?: number;
+  statusText?: string;
+  statusCode?: number;
+  statusMessage?: string;
+
   constructor(message: string, opts?: { cause: unknown }) {
     // @ts-ignore https://v8.dev/features/error-cause
     super(message, opts);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#278

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With the latest ofetch version, the `FetchError` does implement the `IFetchError` interface, but TS won't provide the types. Thus, only `message`, `stack` etc. properties are available.

Since the `FetchError` will be initiated by `createFetchError`, we can add the properties from the interface directly in the class definition, without the need of setting them in the constructor. With these changes, TypeScript understands.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
