### PR TITLE
feat: export all types

### DIFF
--- a/src/error.ts
+++ b/src/error.ts
@@ -1,20 +1,4 @@
-import type {
-  FetchContext,
-  FetchOptions,
-  FetchRequest,
-  FetchResponse,
-} from "./fetch";
-
-export interface IFetchError<T = any> extends Error {
-  request?: FetchRequest;
-  options?: FetchOptions;
-  response?: FetchResponse<T>;
-  data?: T;
-  status?: number;
-  statusText?: string;
-  statusCode?: number;
-  statusMessage?: string;
-}
+import type { FetchContext, IFetchError } from "./types";
 
 export class FetchError<T = any> extends Error implements IFetchError<T> {
   constructor(message: string, opts?: { cause: unknown }) {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -9,7 +9,6 @@ import {
   mergeFetchOptions,
 } from "./utils";
 import type {
-  RequestInit,
   CreateFetchOptions,
   FetchResponse,
   FetchContext,

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,14 +1,6 @@
 import type { Readable } from "node:stream";
 import destr from "destr";
 import { withBase, withQuery } from "ufo";
-import type {
-  Fetch,
-  RequestInfo,
-  RequestInit,
-  Response,
-  ResponseType,
-  MappedType,
-} from "./types";
 import { createFetchError } from "./error";
 import {
   isPayloadMethod,
@@ -16,81 +8,13 @@ import {
   detectResponseType,
   mergeFetchOptions,
 } from "./utils";
-
-export interface CreateFetchOptions {
-  // eslint-disable-next-line no-use-before-define
-  defaults?: FetchOptions;
-  fetch?: Fetch;
-  Headers?: typeof Headers;
-  AbortController?: typeof AbortController;
-}
-
-export type FetchRequest = RequestInfo;
-export interface FetchResponse<T> extends Response {
-  _data?: T;
-}
-export interface SearchParameters {
-  [key: string]: any;
-}
-
-export interface FetchContext<T = any, R extends ResponseType = ResponseType> {
-  request: FetchRequest;
-  // eslint-disable-next-line no-use-before-define
-  options: FetchOptions<R>;
-  response?: FetchResponse<T>;
-  error?: Error;
-}
-
-export interface FetchOptions<R extends ResponseType = ResponseType>
-  extends Omit<RequestInit, "body"> {
-  baseURL?: string;
-  body?: RequestInit["body"] | Record<string, any>;
-  ignoreResponseError?: boolean;
-  params?: SearchParameters;
-  query?: SearchParameters;
-  parseResponse?: (responseText: string) => any;
-  responseType?: R;
-
-  /**
-   * @experimental Set to "half" to enable duplex streaming.
-   * Will be automatically set to "half" when using a ReadableStream as body.
-   * https://fetch.spec.whatwg.org/#enumdef-requestduplex
-   */
-  duplex?: "half" | undefined;
-
-  /** timeout in milliseconds */
-  timeout?: number;
-
-  retry?: number | false;
-  /** Delay between retries in milliseconds. */
-  retryDelay?: number;
-  /** Default is [408, 409, 425, 429, 500, 502, 503, 504] */
-  retryStatusCodes?: number[];
-
-  onRequest?(context: FetchContext): Promise<void> | void;
-  onRequestError?(
-    context: FetchContext & { error: Error }
-  ): Promise<void> | void;
-  onResponse?(
-    context: FetchContext & { response: FetchResponse<R> }
-  ): Promise<void> | void;
-  onResponseError?(
-    context: FetchContext & { response: FetchResponse<R> }
-  ): Promise<void> | void;
-}
-
-export interface $Fetch {
-  <T = any, R extends ResponseType = "json">(
-    request: FetchRequest,
-    options?: FetchOptions<R>
-  ): Promise<MappedType<R, T>>;
-  raw<T = any, R extends ResponseType = "json">(
-    request: FetchRequest,
-    options?: FetchOptions<R>
-  ): Promise<FetchResponse<MappedType<R, T>>>;
-  native: Fetch;
-  create(defaults: FetchOptions): $Fetch;
-}
+import type {
+  RequestInit,
+  CreateFetchOptions,
+  FetchResponse,
+  FetchContext,
+  $Fetch,
+} from "./types";
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
 const retryStatusCodes = new Set([

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,14 +1,19 @@
 import type { Readable } from "node:stream";
 import destr from "destr";
 import { withBase, withQuery } from "ufo";
-import type { Fetch, RequestInfo, RequestInit, Response } from "./types";
+import type {
+  Fetch,
+  RequestInfo,
+  RequestInit,
+  Response,
+  ResponseType,
+  MappedType,
+} from "./types";
 import { createFetchError } from "./error";
 import {
   isPayloadMethod,
   isJSONSerializable,
   detectResponseType,
-  ResponseType,
-  MappedType,
   mergeFetchOptions,
 } from "./utils";
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { createFetch } from "./base";
 
 export * from "./base";
+export type { ResponseType, ResponseMap, MappedType } from "./utils";
 
 // ref: https://github.com/tc39/proposal-global
 const _globalThis = (function () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,18 @@ import { createFetch } from "./base";
 
 export * from "./base";
 
-export type { ResponseType, ResponseMap, MappedType } from "./types";
+export type {
+  $Fetch,
+  FetchRequest,
+  FetchOptions,
+  FetchContext,
+  FetchResponse,
+  CreateFetchOptions,
+  IFetchError,
+  ResponseType,
+  ResponseMap,
+  MappedType,
+} from "./types";
 
 // ref: https://github.com/tc39/proposal-global
 const _globalThis = (function () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,7 +12,7 @@ export type {
   IFetchError,
   ResponseType,
   ResponseMap,
-  MappedType,
+  MappedResponseType,
 } from "./types";
 
 // ref: https://github.com/tc39/proposal-global

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,8 @@
 import { createFetch } from "./base";
 
 export * from "./base";
-export type { ResponseType, ResponseMap, MappedType } from "./utils";
+
+export type { ResponseType, ResponseMap, MappedType } from "./types";
 
 // ref: https://github.com/tc39/proposal-global
 const _globalThis = (function () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,18 +2,7 @@ import { createFetch } from "./base";
 
 export * from "./base";
 
-export type {
-  $Fetch,
-  FetchRequest,
-  FetchOptions,
-  FetchContext,
-  FetchResponse,
-  CreateFetchOptions,
-  IFetchError,
-  ResponseType,
-  ResponseMap,
-  MappedResponseType,
-} from "./types";
+export type * from "./types";
 
 // ref: https://github.com/tc39/proposal-global
 const _globalThis = (function () {

--- a/src/types.ts
+++ b/src/types.ts
@@ -118,9 +118,10 @@ export interface IFetchError<T = any> extends Error {
 // Other types
 // --------------------------
 
+export type Fetch = typeof globalThis.fetch;
+
 export type FetchRequest = RequestInfo;
+
 export interface SearchParameters {
   [key: string]: any;
 }
-
-export type Fetch = typeof globalThis.fetch;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,7 +1,85 @@
+// Internal shortcuts
 export type Fetch = typeof globalThis.fetch;
 export type RequestInfo = globalThis.RequestInfo;
 export type RequestInit = globalThis.RequestInit;
 export type Response = globalThis.Response;
+
+export interface CreateFetchOptions {
+  // eslint-disable-next-line no-use-before-define
+  defaults?: FetchOptions;
+  fetch?: Fetch;
+  Headers?: typeof Headers;
+  AbortController?: typeof AbortController;
+}
+
+export type FetchRequest = RequestInfo;
+
+export interface FetchResponse<T> extends Response {
+  _data?: T;
+}
+
+export interface SearchParameters {
+  [key: string]: any;
+}
+
+export interface FetchContext<T = any, R extends ResponseType = ResponseType> {
+  request: FetchRequest;
+  // eslint-disable-next-line no-use-before-define
+  options: FetchOptions<R>;
+  response?: FetchResponse<T>;
+  error?: Error;
+}
+
+export interface FetchOptions<R extends ResponseType = ResponseType>
+  extends Omit<RequestInit, "body"> {
+  baseURL?: string;
+  body?: RequestInit["body"] | Record<string, any>;
+  ignoreResponseError?: boolean;
+  params?: SearchParameters;
+  query?: SearchParameters;
+  parseResponse?: (responseText: string) => any;
+  responseType?: R;
+
+  /**
+   * @experimental Set to "half" to enable duplex streaming.
+   * Will be automatically set to "half" when using a ReadableStream as body.
+   * https://fetch.spec.whatwg.org/#enumdef-requestduplex
+   */
+  duplex?: "half" | undefined;
+
+  /** timeout in milliseconds */
+  timeout?: number;
+
+  retry?: number | false;
+  /** Delay between retries in milliseconds. */
+  retryDelay?: number;
+  /** Default is [408, 409, 425, 429, 500, 502, 503, 504] */
+  retryStatusCodes?: number[];
+
+  onRequest?(context: FetchContext): Promise<void> | void;
+  onRequestError?(
+    context: FetchContext & { error: Error }
+  ): Promise<void> | void;
+  onResponse?(
+    context: FetchContext & { response: FetchResponse<R> }
+  ): Promise<void> | void;
+  onResponseError?(
+    context: FetchContext & { response: FetchResponse<R> }
+  ): Promise<void> | void;
+}
+
+export interface $Fetch {
+  <T = any, R extends ResponseType = "json">(
+    request: FetchRequest,
+    options?: FetchOptions<R>
+  ): Promise<MappedType<R, T>>;
+  raw<T = any, R extends ResponseType = "json">(
+    request: FetchRequest,
+    options?: FetchOptions<R>
+  ): Promise<FetchResponse<MappedType<R, T>>>;
+  native: Fetch;
+  create(defaults: FetchOptions): $Fetch;
+}
 
 export interface ResponseMap {
   blob: Blob;
@@ -16,3 +94,14 @@ export type MappedType<
   R extends ResponseType,
   JsonType = any,
 > = R extends keyof ResponseMap ? ResponseMap[R] : JsonType;
+
+export interface IFetchError<T = any> extends Error {
+  request?: FetchRequest;
+  options?: FetchOptions;
+  response?: FetchResponse<T>;
+  data?: T;
+  status?: number;
+  statusText?: string;
+  statusCode?: number;
+  statusMessage?: string;
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,3 +2,17 @@ export type Fetch = typeof globalThis.fetch;
 export type RequestInfo = globalThis.RequestInfo;
 export type RequestInit = globalThis.RequestInit;
 export type Response = globalThis.Response;
+
+export interface ResponseMap {
+  blob: Blob;
+  text: string;
+  arrayBuffer: ArrayBuffer;
+  stream: ReadableStream<Uint8Array>;
+}
+
+export type ResponseType = keyof ResponseMap | "json";
+
+export type MappedType<
+  R extends ResponseType,
+  JsonType = any,
+> = R extends keyof ResponseMap ? ResponseMap[R] : JsonType;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,26 +1,23 @@
-// Internal shortcuts
-export type Fetch = typeof globalThis.fetch;
-export type RequestInfo = globalThis.RequestInfo;
-export type RequestInit = globalThis.RequestInit;
-export type Response = globalThis.Response;
+// --------------------------
+// $fetch API
+// --------------------------
 
-export interface CreateFetchOptions {
-  // eslint-disable-next-line no-use-before-define
-  defaults?: FetchOptions;
-  fetch?: Fetch;
-  Headers?: typeof Headers;
-  AbortController?: typeof AbortController;
+export interface $Fetch {
+  <T = any, R extends ResponseType = "json">(
+    request: FetchRequest,
+    options?: FetchOptions<R>
+  ): Promise<MappedResponseType<R, T>>;
+  raw<T = any, R extends ResponseType = "json">(
+    request: FetchRequest,
+    options?: FetchOptions<R>
+  ): Promise<FetchResponse<MappedResponseType<R, T>>>;
+  native: Fetch;
+  create(defaults: FetchOptions): $Fetch;
 }
 
-export type FetchRequest = RequestInfo;
-
-export interface FetchResponse<T> extends Response {
-  _data?: T;
-}
-
-export interface SearchParameters {
-  [key: string]: any;
-}
+// --------------------------
+// Context
+// --------------------------
 
 export interface FetchContext<T = any, R extends ResponseType = ResponseType> {
   request: FetchRequest;
@@ -30,13 +27,17 @@ export interface FetchContext<T = any, R extends ResponseType = ResponseType> {
   error?: Error;
 }
 
+// --------------------------
+// Options
+// --------------------------
+
 export interface FetchOptions<R extends ResponseType = ResponseType>
   extends Omit<RequestInit, "body"> {
   baseURL?: string;
   body?: RequestInit["body"] | Record<string, any>;
   ignoreResponseError?: boolean;
-  params?: SearchParameters;
-  query?: SearchParameters;
+  params?: Record<string, any>;
+  query?: Record<string, any>;
   parseResponse?: (responseText: string) => any;
   responseType?: R;
 
@@ -68,18 +69,17 @@ export interface FetchOptions<R extends ResponseType = ResponseType>
   ): Promise<void> | void;
 }
 
-export interface $Fetch {
-  <T = any, R extends ResponseType = "json">(
-    request: FetchRequest,
-    options?: FetchOptions<R>
-  ): Promise<MappedResponseType<R, T>>;
-  raw<T = any, R extends ResponseType = "json">(
-    request: FetchRequest,
-    options?: FetchOptions<R>
-  ): Promise<FetchResponse<MappedResponseType<R, T>>>;
-  native: Fetch;
-  create(defaults: FetchOptions): $Fetch;
+export interface CreateFetchOptions {
+  // eslint-disable-next-line no-use-before-define
+  defaults?: FetchOptions;
+  fetch?: Fetch;
+  Headers?: typeof Headers;
+  AbortController?: typeof AbortController;
 }
+
+// --------------------------
+// Response Types
+// --------------------------
 
 export interface ResponseMap {
   blob: Blob;
@@ -95,6 +95,14 @@ export type MappedResponseType<
   JsonType = any,
 > = R extends keyof ResponseMap ? ResponseMap[R] : JsonType;
 
+export interface FetchResponse<T> extends Response {
+  _data?: T;
+}
+
+// --------------------------
+// Error
+// --------------------------
+
 export interface IFetchError<T = any> extends Error {
   request?: FetchRequest;
   options?: FetchOptions;
@@ -105,3 +113,14 @@ export interface IFetchError<T = any> extends Error {
   statusCode?: number;
   statusMessage?: string;
 }
+
+// --------------------------
+// Other types
+// --------------------------
+
+export type FetchRequest = RequestInfo;
+export interface SearchParameters {
+  [key: string]: any;
+}
+
+export type Fetch = typeof globalThis.fetch;

--- a/src/types.ts
+++ b/src/types.ts
@@ -72,11 +72,11 @@ export interface $Fetch {
   <T = any, R extends ResponseType = "json">(
     request: FetchRequest,
     options?: FetchOptions<R>
-  ): Promise<MappedType<R, T>>;
+  ): Promise<MappedResponseType<R, T>>;
   raw<T = any, R extends ResponseType = "json">(
     request: FetchRequest,
     options?: FetchOptions<R>
-  ): Promise<FetchResponse<MappedType<R, T>>>;
+  ): Promise<FetchResponse<MappedResponseType<R, T>>>;
   native: Fetch;
   create(defaults: FetchOptions): $Fetch;
 }
@@ -90,7 +90,7 @@ export interface ResponseMap {
 
 export type ResponseType = keyof ResponseMap | "json";
 
-export type MappedType<
+export type MappedResponseType<
   R extends ResponseType,
   JsonType = any,
 > = R extends keyof ResponseMap ? ResponseMap[R] : JsonType;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import type { FetchOptions } from "./fetch";
+import type { ResponseType } from "./types";
 
 const payloadMethods = new Set(
   Object.freeze(["PATCH", "POST", "PUT", "DELETE"])
@@ -38,19 +39,6 @@ const textTypes = new Set([
 ]);
 
 const JSON_RE = /^application\/(?:[\w!#$%&*.^`~-]*\+)?json(;.+)?$/i;
-
-export interface ResponseMap {
-  blob: Blob;
-  text: string;
-  arrayBuffer: ArrayBuffer;
-  stream: ReadableStream<Uint8Array>;
-}
-
-export type ResponseType = keyof ResponseMap | "json";
-export type MappedType<
-  R extends ResponseType,
-  JsonType = any,
-> = R extends keyof ResponseMap ? ResponseMap[R] : JsonType;
 
 // This provides reasonable defaults for the correct parser based on Content-Type header.
 export function detectResponseType(_contentType = ""): ResponseType {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
-import type { FetchOptions } from "./fetch";
-import type { ResponseType } from "./types";
+import type { FetchOptions, ResponseType } from "./types";
 
 const payloadMethods = new Set(
   Object.freeze(["PATCH", "POST", "PUT", "DELETE"])


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I'm building a library around ofetch that needs defines custom fetch functions with the same signature as ofetch, so ideally I would have access to these types to define the function. My current workaround is to copy-paste the types into the library but this doesn't feel quite right.

If there's a reason for these types to not be exported, just close this PR and I will stick to the workaround 👍🏼

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
