### PR TITLE
feat: expose `GlobalOptions` type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { createFetch } from "./base";
 
 export * from "./base";
 
-export type * from "./types";
+export * from "./types";
 
 // ref: https://github.com/tc39/proposal-global
 const _globalThis = (function () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@ import { createFetch } from "./base";
 
 export * from "./base";
 
-export * from "./types";
+export type * from "./types";
 
 // ref: https://github.com/tc39/proposal-global
 const _globalThis = (function () {

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,7 +77,7 @@ export interface CreateFetchOptions {
   AbortController?: typeof AbortController;
 }
 
-export type SharedOptions = Pick<
+export type GlobalOptions = Pick<
   FetchOptions,
   "timeout" | "retry" | "retryDelay"
 >;

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,11 @@ export interface CreateFetchOptions {
   AbortController?: typeof AbortController;
 }
 
+export type SharedOptions = Pick<
+  FetchOptions,
+  "timeout" | "retry" | "retryDelay"
+>;
+
 // --------------------------
 // Response Types
 // --------------------------


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #302

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR exposes `SharedOptions` type, a sub type of `FetchOptions` that is completely safe to be shared in reusable instances via global configuration.  (currently timeout, retry and retryDelay) other things in the future such as respectProxy might be included.

The border between choosing if something is safe to be global option or not is that it should not affect any runtime logic behavior changes.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
