### PR TITLE
fix: types resolution when using typescript moduleResolution bundler

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
+      "types": "./dist/index.d.mts",
       "browser": "./dist/index.mjs",
       "bun": "./dist/index.mjs",
       "deno": "./dist/index.mjs",
@@ -38,7 +39,6 @@
         "types": "./dist/node.d.cts",
         "default": "./dist/node.cjs"
       },
-      "types": "./dist/index.d.mts",
       "default": "./dist/index.mjs"
     },
     "./node": {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

New Typescript bundler resolution algorith picks first matched option, if types are at the end it is likely other option will be matched first and error will be shown `Cannot find module 'ofetch' or its corresponding type declarations.ts(2307) pnpm`

More context as for why can be found here by core Typescript maintainer [here](https://twitter.com/atcb/status/1714685984380694662).

TLDR. Put types field first.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
