### PR TITLE
feat: have both local and global interceptors

### DIFF
--- a/playground/index.ts
+++ b/playground/index.ts
@@ -1,8 +1,21 @@
 import { $fetch } from "../src/node";
 
+const myFetch = $fetch.create({
+  onResponse: {
+    strategy: "after",
+    handler(ctx, data) {
+      return 'global: ' + data
+    },
+  }
+})
+
 async function main() {
+  const r = await myFetch<string>("http://httpstat.us/200", {
+    onResponse(ctx, data) {
+      return 'local -> ' + data
+    }
+  });
   // const r = await $fetch<string>('http://google.com/404')
-  const r = await $fetch<string>("http://httpstat.us/500");
   // const r = await $fetch<string>('http://httpstat/500')
   // eslint-disable-next-line no-console
   console.log(r);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

Closes
- https://github.com/unjs/ofetch/issues/319
- https://github.com/unjs/ofetch/issues/160
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Currently interceptors specified in $fetch() override the interceptors in $fetch.create. 
This PR implements:
1. The interceptor "merge strategy" options that allow you to have both default and per-request interceptors. You can add interceptor as an object with `handler` and `strategy` fields when creating new client using `$fetch.create`. Available strategies: 
- 'overwrite' - current behaviour
- 'after' - interceptor in $fetch will be called after the interceptor in $fetch.create
- 'before' - interceptor in $fetch will be called before the interceptor in $fetch.create
- 'manual' - interceptor in $fetch.create decides how/when/if call interceptor from $fetch

In all cases interceptor has second parameter which can be:
- response data
- data return by the previous interceptor 

_Names are subject to change_ 👀 

2. It is now allowed to return new response data from the `onResponse`, `onResponseError` interceptors.
If the function doesn't return anything or returns `undefined` - the response data will not be overwritten.

Example:
```ts
const myFetch = $fetch.create({
  onResponse: {
    strategy: "after",
    handler(ctx, data) {
      return 'global: ' + data
    },
  }
})

const r = await myFetch<string>("http://httpstat.us/200", {
  onResponse(ctx, data) {
    return 'local -> ' + data
  }
})

console.log(r) // will print "local -> global: 200 OK"
```

The open question is how to type the "data" parameter, currently it has type `any`.

We can also introduce the `defaultStrategy` option.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
