### PR TITLE
feat: retry callback

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,10 +129,13 @@ The default for `retry` is `1` retry, except for `POST`, `PUT`, `PATCH`, and `DE
 
 The default for `retryDelay` is `0` ms.
 
+You can also use `retryCb` function to retry on some condition. It takes a fetch context object as an argument.
+
 ```ts
 await ofetch("http://google.com/404", {
   retry: 3,
   retryDelay: 500, // ms
+  retryCb: (ctx) => ctx.error.code === '007'
 });
 ```
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -57,6 +57,8 @@ export interface FetchOptions<R extends ResponseType = ResponseType>
   /** Default is [408, 409, 425, 429, 500, 502, 503, 504] */
   retryStatusCodes?: number[];
 
+  retryCb?: (context: FetchContext) => Promise<boolean> | boolean;
+
   onRequest?(context: FetchContext): Promise<void> | void;
   onRequestError?(
     context: FetchContext & { error: Error }

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -287,6 +287,22 @@ describe("ofetch", () => {
     expect(race).to.equal("fast");
   });
 
+  it("retry callback", async () => {
+    const slow = $fetch<string>(getURL("408"), {
+      retry: 2,
+      retryDelay: 100,
+      retryCb: () => false,
+    }).catch(() => "slow");
+    const fast = $fetch<string>(getURL("408"), {
+      retry: 2,
+      retryDelay: 1,
+      retryCb: () => true,
+    }).catch(() => "fast");
+
+    const race = await Promise.race([slow, fast]);
+    expect(race).to.equal("slow");
+  });
+
   it("abort with retry", () => {
     const controller = new AbortController();
     async function abortHandle() {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -290,12 +290,10 @@ describe("ofetch", () => {
   it("retry callback", async () => {
     const slow = $fetch<string>(getURL("408"), {
       retry: 2,
-      retryDelay: 100,
       retryCb: () => false,
     }).catch(() => "slow");
     const fast = $fetch<string>(getURL("408"), {
       retry: 2,
-      retryDelay: 1,
       retryCb: () => true,
     }).catch(() => "fast");
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/unjs/ofetch/issues/358

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds new `retryCb` option which is a function that takes a fetch context object and returns a boolean, `true` if the request needs to be retried:

```ts
await $fetch('/cart', {
  retryCb(ctx) {
    return ctx.error.errorId === 'SPECIAL_CODE'
  }
})
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
