### PR TITLE
feat: support `retryDelay` with callback function

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -62,7 +62,9 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
           ? context.options.retryStatusCodes.includes(responseCode)
           : retryStatusCodes.has(responseCode))
       ) {
-        const retryDelay = context.options.retryDelay || 0;
+        const retryDelay = typeof context.options.retryDelay === 'function' ?
+          context.options.retryDelay(context) :
+          context.options.retryDelay || 0;
         if (retryDelay > 0) {
           await new Promise((resolve) => setTimeout(resolve, retryDelay));
         }

--- a/src/types.ts
+++ b/src/types.ts
@@ -53,7 +53,7 @@ export interface FetchOptions<R extends ResponseType = ResponseType>
 
   retry?: number | false;
   /** Delay between retries in milliseconds. */
-  retryDelay?: number;
+  retryDelay?: number | ((context: FetchContext) => number);
   /** Default is [408, 409, 425, 429, 500, 502, 503, 504] */
   retryStatusCodes?: number[];
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -273,7 +273,7 @@ describe("ofetch", () => {
     expect(error.request).to.equal(getURL("404"));
   });
 
-  it("retry with delay", async () => {
+  it("retry with number delay", async () => {
     const slow = $fetch<string>(getURL("408"), {
       retry: 2,
       retryDelay: 100,
@@ -281,6 +281,20 @@ describe("ofetch", () => {
     const fast = $fetch<string>(getURL("408"), {
       retry: 2,
       retryDelay: 1,
+    }).catch(() => "fast");
+
+    const race = await Promise.race([slow, fast]);
+    expect(race).to.equal("fast");
+  });
+
+  it("retry with callback delay", async () => {
+    const slow = $fetch<string>(getURL("408"), {
+      retry: 2,
+      retryDelay: () => 100,
+    }).catch(() => "slow");
+    const fast = $fetch<string>(getURL("408"), {
+      retry: 2,
+      retryDelay: () => 1,
     }).catch(() => "fast");
 
     const race = await Promise.race([slow, fast]);


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Calculate retry delay based on context. 
Opens possibility to make retries with incremental delay. For example:
```typescript
{
  retry: 3,
  retryDelay: (context) => {
      const attempt = context.options.retryAttempt = (context.options.retryAttempt || 0) + 1;
      return 300 * (Math.pow(3, attempt - 1))
  },
}
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
