### PR TITLE
feat: have both local and global interceptors

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -162,7 +162,6 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
       );
     } catch (error) {
       context.error = error as Error;
-      console.log("context.onRequestError", context.options.onRequestError);
       await callInterceptors(context, "onRequestError");
       return await onError(context);
     }
@@ -203,7 +202,6 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
       context.response.status >= 400 &&
       context.response.status < 600
     ) {
-      console.log("context.response", context.response);
       await callInterceptors(context, "onResponseError");
       return await onError(context);
     }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -7,6 +7,7 @@ import {
   isJSONSerializable,
   detectResponseType,
   mergeFetchOptions,
+  callInterceptors,
 } from "./utils";
 import type {
   CreateFetchOptions,
@@ -99,9 +100,7 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
     // Uppercase method name
     context.options.method = context.options.method?.toUpperCase();
 
-    if (context.options.onRequest) {
-      await context.options.onRequest(context);
-    }
+    await callInterceptors(context, "onRequest");
 
     if (typeof context.request === "string") {
       if (context.options.baseURL) {
@@ -163,9 +162,8 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
       );
     } catch (error) {
       context.error = error as Error;
-      if (context.options.onRequestError) {
-        await context.options.onRequestError(context as any);
-      }
+      console.log("context.onRequestError", context.options.onRequestError);
+      await callInterceptors(context, "onRequestError");
       return await onError(context);
     }
 
@@ -198,18 +196,15 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
       }
     }
 
-    if (context.options.onResponse) {
-      await context.options.onResponse(context as any);
-    }
+    await callInterceptors(context, "onResponse");
 
     if (
       !context.options.ignoreResponseError &&
       context.response.status >= 400 &&
       context.response.status < 600
     ) {
-      if (context.options.onResponseError) {
-        await context.options.onResponseError(context as any);
-      }
+      console.log("context.response", context.response);
+      await callInterceptors(context, "onResponseError");
       return await onError(context);
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -28,6 +28,14 @@ export interface FetchContext<T = any, R extends ResponseType = ResponseType> {
 }
 
 // --------------------------
+// Interceptor
+// --------------------------
+export type InterceptorCb<T> = (context: T) => Promise<void> | void;
+export type Interceptor<T> =
+  | InterceptorCb<T>
+  | { enforce: "default" | "pre" | "post"; handler: InterceptorCb<T> };
+
+// --------------------------
 // Options
 // --------------------------
 
@@ -57,16 +65,14 @@ export interface FetchOptions<R extends ResponseType = ResponseType>
   /** Default is [408, 409, 425, 429, 500, 502, 503, 504] */
   retryStatusCodes?: number[];
 
-  onRequest?(context: FetchContext): Promise<void> | void;
-  onRequestError?(
-    context: FetchContext & { error: Error }
-  ): Promise<void> | void;
-  onResponse?(
-    context: FetchContext & { response: FetchResponse<R> }
-  ): Promise<void> | void;
-  onResponseError?(
-    context: FetchContext & { response: FetchResponse<R> }
-  ): Promise<void> | void;
+  onRequest?: Arrayable<Interceptor<FetchContext>>;
+  onRequestError?: Arrayable<Interceptor<FetchContext & { error: Error }>>;
+  onResponse?: Arrayable<
+    Interceptor<FetchContext & { response: FetchResponse<R> }>
+  >;
+  onResponseError?: Arrayable<
+    Interceptor<FetchContext & { response: FetchResponse<R> }>
+  >;
 }
 
 export interface CreateFetchOptions {
@@ -130,3 +136,5 @@ export type FetchRequest = RequestInfo;
 export interface SearchParameters {
   [key: string]: any;
 }
+
+export type Arrayable<T> = T[] | T;


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

https://github.com/unjs/ofetch/issues/319

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently interceptors specified in $fetch() override the interceptors in $fetch.create.

This PR adds support for interceptors as an array, so we can merge arrays from $fetch and $fetch.create. 
It also allows set an `enforce` option, so that interceptors from $fetch and $fetch.create can be enforced to append or prepend to the resulting array of interceptors (similar to Nuxt plugins):
```ts
const $myFetch = $fetch.create({
  onRequest: [
    (ctx) => { /* Handler 1 */ }, // same as "enforce: 'default'"
    {
      enforce: 'post',
      handler: (ctx) => { /* Handler 2 */ }
    }
  ]
})

$myFetch({
  onRequest: [
    // Will be appended 
    (ctx) => { /* Handler 3 */ },
    // If you need to prepend in some scenarios
    {
      enforce: 'pre',
      handler: (ctx) => { /* Handler 4 */ }
    }
  ]
})

// Interceptors will be executed in this order:
/*
Handler 4
Handler 1
Handler 3
Handler 2
*/
```

### Note
This is implemented as a braking change, but we can add the `overrideInterceptors` option to not break the current behavior.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
