### PR TITLE
docs: add docs for using undici dispatcher

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,7 +267,7 @@ await ofetch("/movies", {
 
 If you need use a HTTP(S) / Proxy Agent, you can (for Node.js only):
 
-### Node >= v21
+### Node >= v18
 
 Add `ProxyAgent` to `dispatcher` option with `undici`
 
@@ -280,7 +280,7 @@ await ofetch("/api", {
 });
 ```
 
-### Node < v21
+### Node < v18
 
 Add `HttpsProxyAgent` to `agent` option with `https-proxy-agent`
 

--- a/README.md
+++ b/README.md
@@ -263,9 +263,26 @@ await ofetch("/movies", {
 });
 ```
 
-## 💡 Adding HTTP(S) Agent
+## 💡 Adding a HTTP(S) / Proxy Agent
 
-If you need use HTTP(S) Agent, can add `agent` option with `https-proxy-agent` (for Node.js only):
+If you need use a HTTP(S) / Proxy Agent, you can (for Node.js only):
+
+### Node >= v21
+
+Add `ProxyAgent` to `dispatcher` option with `undici`
+
+```js
+import { ofetch } from 'ofetch'
+import { ProxyAgent } from 'undici'
+
+await ofetch("/api", {
+  dispatcher: new ProxyAgent("http://example.com"),
+});
+```
+
+### Node < v21
+
+Add `HttpsProxyAgent` to `agent` option with `https-proxy-agent`
 
 ```js
 import { HttpsProxyAgent } from "https-proxy-agent";


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

#379, #215, #316

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`agent` setting only applies to older versions of node.
As of version 18 node fetch is native and depends on `undici`, which uses a `dispatcher` option instead

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
