### PR TITLE
fix: use  `response._bodyInit` as fallback for react-native and qq

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -196,6 +196,7 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
     const hasBody =
       (context.response.body ||
         // https://github.com/JakeChampion/fetch/issues/1454
+        // https://github.com/unjs/ofetch/issues/294
         (context.response as any)._bodyInit) &&
       !nullBodyResponses.has(context.response.status) &&
       context.options.method !== "HEAD";
@@ -218,6 +219,7 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
           context.response._data =
             context.response.body ||
             // https://github.com/JakeChampion/fetch/issues/1454
+            // https://github.com/unjs/ofetch/issues/294
             (context.response as any)._bodyInit;
           break;
         }

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -185,7 +185,11 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
     }
 
     const hasBody =
-      context.response.body &&
+      (context.response.body ||
+        // React Native whatwg-fetch check. Can be removed when the following occurs
+        // 1) https://github.com/JakeChampion/fetch/issues/1454 is fixed
+        // 2) React Native upgrades to the whatwg-fetch version that has this fix
+        (context.response as any)._bodyInit) &&
       !nullBodyResponses.has(context.response.status) &&
       context.options.method !== "HEAD";
     if (hasBody) {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -218,8 +218,7 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
         }
         case "stream": {
           context.response._data =
-            context.response.body ||            
-            (context.response as any)._bodyInit; // (see refs above)
+            context.response.body || (context.response as any)._bodyInit; // (see refs above)
           break;
         }
         default: {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -195,8 +195,9 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
 
     const hasBody =
       (context.response.body ||
-        // https://github.com/JakeChampion/fetch/issues/1454
+        // https://github.com/unjs/ofetch/issues/324
         // https://github.com/unjs/ofetch/issues/294
+        // https://github.com/JakeChampion/fetch/issues/1454
         (context.response as any)._bodyInit) &&
       !nullBodyResponses.has(context.response.status) &&
       context.options.method !== "HEAD";
@@ -217,10 +218,8 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
         }
         case "stream": {
           context.response._data =
-            context.response.body ||
-            // https://github.com/JakeChampion/fetch/issues/1454
-            // https://github.com/unjs/ofetch/issues/294
-            (context.response as any)._bodyInit;
+            context.response.body ||            
+            (context.response as any)._bodyInit; // (see refs above)
           break;
         }
         default: {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -215,7 +215,10 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
           break;
         }
         case "stream": {
-          context.response._data = context.response.body;
+          context.response._data =
+            context.response.body ||
+            // https://github.com/JakeChampion/fetch/issues/1454
+            (context.response as any)._bodyInit;
           break;
         }
         default: {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -195,9 +195,7 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
 
     const hasBody =
       (context.response.body ||
-        // React Native whatwg-fetch check. Can be removed when the following occurs
-        // 1) https://github.com/JakeChampion/fetch/issues/1454 is fixed
-        // 2) React Native upgrades to the whatwg-fetch version that has this fix
+        // https://github.com/JakeChampion/fetch/issues/1454
         (context.response as any)._bodyInit) &&
       !nullBodyResponses.has(context.response.status) &&
       context.options.method !== "HEAD";


### PR DESCRIPTION
<!---
    ☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Fixes #324 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pr is essentially a one line change to add react native support. It checks `response._bodyInit` in addition to `response.body` to see if a body exists in the response.

Normally I would say that this is an upstream issue that react native should fix, but the reality is fetch has not been spec compliant in react native for a long time, and it doesn't seem like there has been any meaningful progress in that department either. So I don't think it's practical to wait on them. 

I would also argue that even though this is a runtime specific check it shouldn't add any overhead for maintainers because its such a small change. I've also included comments explaining what the additional `_bodyInit` check is for and under what conditions it can be removed.

Additionally this repo does have a precedent for runtime specific check. In `./src/fetch.ts` line 84, there is a check for a chromium specific API. So this change would be in line with that.
https://github.com/unjs/ofetch/blob/f7f946395544f3ab39fd2e5c61110b5371d7e9dd/src/fetch.ts#L84

In all I think this is a worthwhile change as it would let users use the same fetch library across, node, browsers, and react native.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
