### PR TITLE
feat: allow custom global options for `$fetch.create`

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -240,13 +240,13 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
 
   $fetch.native = (...args) => fetch(...args);
 
-  $fetch.create = (defaultOptions = {}, globalOptionsOverwrite = {}) =>
+  $fetch.create = (defaultOptions = {}, customGlobalOptions = {}) =>
     createFetch({
       ...globalOptions,
-      ...globalOptionsOverwrite,
+      ...customGlobalOptions,
       defaults: {
         ...globalOptions.defaults,
-        ...globalOptionsOverwrite.defaults,
+        ...customGlobalOptions.defaults,
         ...defaultOptions,
       },
     });

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -240,10 +240,7 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
 
   $fetch.native = (...args) => fetch(...args);
 
-  $fetch.create = (
-    defaultOptions = {},
-    globalOptionsOverwrite = {}
-  ) =>
+  $fetch.create = (defaultOptions = {}, globalOptionsOverwrite = {}) =>
     createFetch({
       ...globalOptions,
       ...globalOptionsOverwrite,

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -240,9 +240,13 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
 
   $fetch.native = (...args) => fetch(...args);
 
-  $fetch.create = (defaultOptions = {}) =>
+  $fetch.create = (
+    defaultOptions = {},
+    globalOptionsOverwrite?: CreateFetchOptions
+  ) =>
     createFetch({
       ...globalOptions,
+      ...globalOptionsOverwrite,
       defaults: {
         ...globalOptions.defaults,
         ...defaultOptions,

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -242,13 +242,14 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
 
   $fetch.create = (
     defaultOptions = {},
-    globalOptionsOverwrite?: CreateFetchOptions
+    globalOptionsOverwrite = {}
   ) =>
     createFetch({
       ...globalOptions,
       ...globalOptionsOverwrite,
       defaults: {
         ...globalOptions.defaults,
+        ...globalOptionsOverwrite.defaults,
         ...defaultOptions,
       },
     });

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,7 +12,7 @@ export interface $Fetch {
     options?: FetchOptions<R>
   ): Promise<FetchResponse<MappedResponseType<R, T>>>;
   native: Fetch;
-  create(defaults: FetchOptions): $Fetch;
+  create(defaults: FetchOptions, globalOptions?: CreateFetchOptions): $Fetch;
 }
 
 // --------------------------


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
#71

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
This commit adds an optional parameter `globalOptionsOverwrite`  to  `$fetch.create`.  
<!-- Why is this change required? What problem does it solve? -->
However, for HTTP, headers are not case-sensitive. But for some reason, headers are case-sensitive in some old backend frameworks. This optional parameter overrides native `Headers` behaviour in such situations.
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

As only adding an optional parameter, it won`t break anything, maybe?

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
