### PR TITLE
fix: export types from `node` export condition

### DIFF
--- a/src/node.ts
+++ b/src/node.ts
@@ -8,6 +8,7 @@ import nodeFetch, {
 import { createFetch } from "./base";
 
 export * from "./base";
+export type * from "./types";
 
 export function createNodeFetch() {
   const useKeepAlive = JSON.parse(process.env.FETCH_KEEP_ALIVE || "false");


### PR DESCRIPTION
Looking at resolving type issues in https://github.com/nuxt/nuxt/pull/27702, it seems we don't have types exported from `node` declarations in `ofetch`, which means they can't be resolved/imported in some environments.

