### PR TITLE
chore: add experimental for `Too Early` status

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ await ofetch("/url", { ignoreResponseError: true });
 
 - `408` - Request Timeout
 - `409` - Conflict
-- `425` - Too Early (Experimental)
+- `425` - Too Early ([Experimental](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Early-Data))
 - `429` - Too Many Requests
 - `500` - Internal Server Error
 - `502` - Bad Gateway

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ await ofetch("/url", { ignoreResponseError: true });
 
 - `408` - Request Timeout
 - `409` - Conflict
-- `425` - Too Early
+- `425` - Too Early (Experimental)
 - `429` - Too Many Requests
 - `500` - Internal Server Error
 - `502` - Bad Gateway

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -19,7 +19,7 @@ import type {
 const retryStatusCodes = new Set([
   408, // Request Timeout
   409, // Conflict
-  425, // Too Early
+  425, // Too Early (Experimental)
   429, // Too Many Requests
   500, // Internal Server Error
   502, // Bad Gateway


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
425 Too Early status is still experimental technology. I think may be adding experimental could be good for understanding.
https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Early-Data
https://developer.mozilla.org/en-US/docs/Web/HTTP/Status#client_error_responses 