### PR TITLE
perf: add typed arrays

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -16,16 +16,18 @@ import type {
 } from "./types";
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
-const retryStatusCodes = new Set(new Int16Array([
-  408, // Request Timeout
-  409, // Conflict
-  425, // Too Early (Experimental)
-  429, // Too Many Requests
-  500, // Internal Server Error
-  502, // Bad Gateway
-  503, // Service Unavailable
-  504, // Gateway Timeout
-]));
+const retryStatusCodes = new Set(
+  new Int16Array([
+    408, // Request Timeout
+    409, // Conflict
+    425, // Too Early (Experimental)
+    429, // Too Many Requests
+    500, // Internal Server Error
+    502, // Bad Gateway
+    503, // Service Unavailable
+    504, // Gateway Timeout
+  ])
+);
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Response/body
 const nullBodyResponses = new Set(new Int16Array([101, 204, 205, 304]));

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -16,7 +16,7 @@ import type {
 } from "./types";
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
-const retryStatusCodes = new Set([
+const retryStatusCodes = new Set(new Int16Array([
   408, // Request Timeout
   409, // Conflict
   425, // Too Early (Experimental)
@@ -25,10 +25,10 @@ const retryStatusCodes = new Set([
   502, // Bad Gateway
   503, // Service Unavailable
   504, // Gateway Timeout
-]);
+]));
 
 // https://developer.mozilla.org/en-US/docs/Web/API/Response/body
-const nullBodyResponses = new Set([101, 204, 205, 304]);
+const nullBodyResponses = new Set(new Int16Array([101, 204, 205, 304]));
 
 export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
   const {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

Typed Arrays are added for `retryStatusCodes` and `nullBodyResponses`. I think may be typed arrays are considered more memory efficient.