### PR TITLE
fix: remove `node:` prefix from import statement for `webpack + nuxt bridge`

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,4 +1,4 @@
-import type { Readable } from "node:stream";
+import type { Readable } from "stream";
 import destr from "destr";
 import { withBase, withQuery } from "ufo";
 import { createFetchError } from "./error";

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,5 +1,5 @@
-import http from "node:http";
-import https, { AgentOptions } from "node:https";
+import http from "http";
+import https, { AgentOptions } from "https";
 import nodeFetch, {
   Headers as _Headers,
   AbortController as _AbortController,


### PR DESCRIPTION
I am currently developing in a 'bridge + webpack' environment and found an error while trying to integrate ofetch in advance for migration. 
The error is the same as the issue reported in the bridge repository below. 
From what I have identified, imports with the 'node:' prefix do not work properly and need to be removed for the 'webpack + bridge' environment to function correctly.

![스크린샷 2024-08-28 오후 5 54 50](https://github.com/user-attachments/assets/cf460ece-6633-49a5-8675-74b69cd72920)

issue: https://github.com/nuxt/bridge/issues/1066 ( bridge )
reproduction: https://github.com/kyumoon/nuxt-birdge-example/tree/test/ofetch


