### PR TITLE
feat: always clone and normalize `options.headers` and `options.query`

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -98,6 +98,7 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
     const context: FetchContext = {
       request: _request,
       options: resolveFetchOptions<R, T>(
+        _request,
         _options,
         globalOptions.defaults as unknown as FetchOptions<R, T>,
         Headers

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -6,14 +6,17 @@ import {
   isPayloadMethod,
   isJSONSerializable,
   detectResponseType,
-  mergeFetchOptions,
+  resolveFetchOptions,
   callHooks,
 } from "./utils";
 import type {
   CreateFetchOptions,
   FetchResponse,
+  ResponseType,
   FetchContext,
   $Fetch,
+  FetchRequest,
+  FetchOptions,
 } from "./types";
 
 // https://developer.mozilla.org/en-US/docs/Web/HTTP/Status
@@ -88,13 +91,17 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
     throw error;
   }
 
-  const $fetchRaw: $Fetch["raw"] = async function $fetchRaw(
-    _request,
-    _options = {}
-  ) {
+  const $fetchRaw: $Fetch["raw"] = async function $fetchRaw<
+    T = any,
+    R extends ResponseType = "json",
+  >(_request: FetchRequest, _options: FetchOptions<R> = {}) {
     const context: FetchContext = {
       request: _request,
-      options: mergeFetchOptions(_options, globalOptions.defaults, Headers),
+      options: resolveFetchOptions<R, T>(
+        _options,
+        globalOptions.defaults as unknown as FetchOptions<R, T>,
+        Headers
+      ),
       response: undefined,
       error: undefined,
     };
@@ -110,11 +117,8 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
       if (context.options.baseURL) {
         context.request = withBase(context.request, context.options.baseURL);
       }
-      if (context.options.query || context.options.params) {
-        context.request = withQuery(context.request, {
-          ...context.options.params,
-          ...context.options.query,
-        });
+      if (context.options.query) {
+        context.request = withQuery(context.request, context.options.query);
       }
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -23,11 +23,17 @@ export interface FetchOptions<R extends ResponseType = ResponseType, T = any>
   extends Omit<RequestInit, "body">,
     FetchHooks<T, R> {
   baseURL?: string;
+
   body?: RequestInit["body"] | Record<string, any>;
+
   ignoreResponseError?: boolean;
+
   params?: Record<string, any>;
+
   query?: Record<string, any>;
+
   parseResponse?: (responseText: string) => any;
+
   responseType?: R;
 
   /**
@@ -61,6 +67,13 @@ export interface FetchOptions<R extends ResponseType = ResponseType, T = any>
   retryStatusCodes?: number[];
 }
 
+export interface ResolvedFetchOptions<
+  R extends ResponseType = ResponseType,
+  T = any,
+> extends Omit<FetchOptions<R, T>, "params"> {
+  headers: Headers;
+}
+
 export interface CreateFetchOptions {
   defaults?: FetchOptions;
   fetch?: Fetch;
@@ -79,7 +92,7 @@ export type GlobalOptions = Pick<
 
 export interface FetchContext<T = any, R extends ResponseType = ResponseType> {
   request: FetchRequest;
-  options: FetchOptions<R>;
+  options: ResolvedFetchOptions<R>;
   response?: FetchResponse<T>;
   error?: Error;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -70,7 +70,7 @@ export interface FetchOptions<R extends ResponseType = ResponseType, T = any>
 export interface ResolvedFetchOptions<
   R extends ResponseType = ResponseType,
   T = any,
-> extends Omit<FetchOptions<R, T>, "params"> {
+> extends FetchOptions<R, T> {
   headers: Headers;
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -2,6 +2,7 @@ import type {
   FetchContext,
   FetchHook,
   FetchOptions,
+  FetchRequest,
   ResolvedFetchOptions,
   ResponseType,
 } from "./types";
@@ -74,12 +75,17 @@ export function resolveFetchOptions<
   R extends ResponseType = ResponseType,
   T = any,
 >(
+  request: FetchRequest,
   input: FetchOptions<R, T> | undefined,
   defaults: FetchOptions<R, T> | undefined,
   Headers: typeof globalThis.Headers
 ): ResolvedFetchOptions<R, T> {
   // Merge headers
-  const headers = mergeHeaders(input?.headers, defaults?.headers, Headers);
+  const headers = mergeHeaders(
+    input?.headers ?? (request as Request)?.headers,
+    defaults?.headers,
+    Headers
+  );
 
   // Merge query/params
   let query: Record<string, any> | undefined;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -96,7 +96,6 @@ export function resolveFetchOptions<
     ...defaults,
     ...input,
     query,
-    // @ts-expect-error backward compatibility
     params: query,
     headers,
   };

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -383,7 +383,9 @@ describe("ofetch", () => {
       "x-header-c": "3",
     });
 
-    expect(path).to.eq("?b=2&c=3&a=1");
+    const parseParams = (str: string) =>
+      Object.fromEntries(new URLSearchParams(str).entries());
+    expect(parseParams(path)).toMatchObject(parseParams("?b=2&c=3&a=1"));
   });
 
   it("calls hooks", async () => {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -388,6 +388,21 @@ describe("ofetch", () => {
     expect(parseParams(path)).toMatchObject(parseParams("?b=2&c=3&a=1"));
   });
 
+  it("uses request headers", async () => {
+    expect(
+      await $fetch(
+        new Request(getURL("echo"), { headers: { foo: "1" } }),
+        {}
+      ).then((r) => r.headers)
+    ).toMatchObject({ foo: "1" });
+
+    expect(
+      await $fetch(new Request(getURL("echo"), { headers: { foo: "1" } }), {
+        headers: { foo: "2", bar: "3" },
+      }).then((r) => r.headers)
+    ).toMatchObject({ foo: "2", bar: "3" });
+  });
+
   it("calls hooks", async () => {
     const onRequest = vi.fn();
     const onRequestError = vi.fn();


### PR DESCRIPTION
resolves #393

This PR adds a change to always normalize `context.options.headers` into a `Headers` object and making sure it is also cloned. 

Additional fixes: 
- If first param to ofetch is a Request, and there is no headers option, it's headers will be used (same as fetch behavior)
- `query` and `params` are now consistent and normalized to the same object.

