### PR TITLE
refactor!: replace `ufo` with native `URL` utils

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -1,6 +1,6 @@
 import type { Readable } from "node:stream";
 import destr from "destr";
-import { withBase, withQuery } from "ufo";
+import { withBase, withQuery } from "./path";
 import { createFetchError } from "./error";
 import {
   isPayloadMethod,

--- a/src/path.ts
+++ b/src/path.ts
@@ -1,0 +1,108 @@
+/* eslint-disable unicorn/prefer-at */
+export type QueryValue =
+  | string
+  | number
+  | boolean
+  | QueryValue[]
+  | Record<string, any>
+  | null
+  | undefined;
+export type QueryObject = Record<string, QueryValue | QueryValue[]>;
+
+/**
+ * Removes the leading slash from the given path if it has one.
+ */
+export function withoutLeadingSlash(path?: string): string {
+  if (!path || path === "/") {
+    return "/";
+  }
+
+  return path[0] === "/" ? path.slice(1) : path;
+}
+
+/**
+ * Removes the trailing slash from the given path if it has one.
+ */
+export function withoutTrailingSlash(path?: string): string {
+  if (!path || path === "/") {
+    return "/";
+  }
+
+  return path[path.length - 1] === "/" ? path.slice(0, -1) : path;
+}
+
+/**
+ * Joins the given base URL and path, ensuring that there is only one slash between them.
+ */
+export function joinURL(base?: string, path?: string): string {
+  if (!base || base === "/") {
+    return path || "/";
+  }
+
+  if (!path || path === "/") {
+    return base || "/";
+  }
+
+  const baseHasTrailing = base[base.length - 1] === "/";
+  const pathHasLeading = path[0] === "/";
+  if (baseHasTrailing && pathHasLeading) {
+    return base + path.slice(1);
+  }
+
+  if (!baseHasTrailing && !pathHasLeading) {
+    return `${base}/${path}`;
+  }
+
+  return base + path;
+}
+
+/**
+ * Adds the base path to the input path, if it is not already present.
+ */
+export function withBase(input = "", base = ""): string {
+  if (!base || base === "/") {
+    return input;
+  }
+
+  const _base = withoutTrailingSlash(base);
+  if (input.startsWith(_base)) {
+    return input;
+  }
+
+  return joinURL(_base, input);
+}
+
+/**
+ * Returns the URL with the given query parameters. If a query parameter is undefined, it is omitted.
+ */
+export function withQuery(input: string, query: QueryObject): string {
+  const url = new URL(input, "http://localhost");
+  const searchParams = new URLSearchParams(url.search);
+
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined) {
+      searchParams.delete(key);
+    } else if (typeof value === "number" || typeof value === "boolean") {
+      searchParams.set(key, String(value));
+    } else if (!value) {
+      searchParams.set(key, "");
+    } else if (Array.isArray(value)) {
+      for (const item of value) {
+        searchParams.append(key, String(item));
+      }
+    } else if (typeof value === "object") {
+      searchParams.set(key, JSON.stringify(value));
+    } else {
+      searchParams.set(key, String(value));
+    }
+  }
+
+  url.search = searchParams.toString();
+  let urlWithQuery = url.toString();
+
+  if (urlWithQuery.startsWith("http://localhost")) {
+    urlWithQuery = urlWithQuery.slice(16);
+  }
+
+  return urlWithQuery;
+}


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->
> [!NOTE]
> This is rather an idea and this PR might be better off over at [`ufo`](https://github.com/unjs/ufo). Feel free to close this PR if it should be handled otherwise.

Migrating `ufo` to use native `URL` [is already in discussion](https://github.com/unjs/ufo/issues/208), which would be beneficial to reduce the bundle size in the whole UnJS ecosystem, I suppose.

In @pi0 work on `h3` v2, `ufo` is no longer used and path utilities [have been internalized to the repo](https://github.com/unjs/h3/blob/main/src/utils/internal/path.ts). This might be also an approach for `ofetch`, since it only uses the following exports:
- `withBase`
- `withQuery`

Taking inspiration from the refactors in `h3` v2, both path utilities have been inlined to remove the dependency on `ofetch`. At the time of writing, one test still fails.

