### PR TITLE
refactor(fetch): Add method aliases for HTTP verbs

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -15,6 +15,7 @@ import type {
   ResponseType,
   FetchContext,
   $Fetch,
+  FetchWithAliases,
   FetchRequest,
   FetchOptions,
 } from "./types";
@@ -246,10 +247,10 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
     return context.response;
   };
 
-  const $fetch = async function $fetch(request, options) {
+  const $fetch: FetchWithAliases = async function $fetch(request, options) {
     const r = await $fetchRaw(request, options);
     return r._data;
-  } as $Fetch;
+  } as FetchWithAliases;
 
   $fetch.raw = $fetchRaw;
 
@@ -265,6 +266,14 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
         ...defaultOptions,
       },
     });
+
+  const methods = ["get", "post", "put", "patch", "delete", "head", "options"];
+
+  for (const method of methods) {
+    $fetch[method] = (request, options = {}) => {
+      return $fetch(request, { ...options, method: method.toUpperCase() });
+    };
+  }
 
   return $fetch;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,7 +13,49 @@ export interface $Fetch {
   ): Promise<FetchResponse<MappedResponseType<R, T>>>;
   native: Fetch;
   create(defaults: FetchOptions, globalOptions?: CreateFetchOptions): $Fetch;
+  // Method Aliases
+  get<T = any, R extends ResponseType = "json">(
+    request: FetchRequest,
+    options?: FetchOptions<R>
+  ): Promise<MappedResponseType<R, T>>;
+
+  post<T = any, R extends ResponseType = "json">(
+    request: FetchRequest,
+    options?: FetchOptions<R>
+  ): Promise<MappedResponseType<R, T>>;
+
+  put<T = any, R extends ResponseType = "json">(
+    request: FetchRequest,
+    options?: FetchOptions<R>
+  ): Promise<MappedResponseType<R, T>>;
+
+  delete<T = any, R extends ResponseType = "json">(
+    request: FetchRequest,
+    options?: FetchOptions<R>
+  ): Promise<MappedResponseType<R, T>>;
+
+  patch<T = any, R extends ResponseType = "json">(
+    request: FetchRequest,
+    options?: FetchOptions<R>
+  ): Promise<MappedResponseType<R, T>>;
+
+  head<T = any, R extends ResponseType = "json">(
+    request: FetchRequest,
+    options?: FetchOptions<R>
+  ): Promise<MappedResponseType<R, T>>;
+
+  options<T = any, R extends ResponseType = "json">(
+    request: FetchRequest,
+    options?: FetchOptions<R>
+  ): Promise<MappedResponseType<R, T>>;
 }
+
+export type FetchWithAliases = $Fetch & {
+  [method: string]: <T = any, R extends ResponseType = "json">(
+    request: FetchRequest,
+    options?: FetchOptions<R>
+  ) => Promise<MappedResponseType<R, T>>;
+};
 
 // --------------------------
 // Options

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -510,4 +510,31 @@ describe("ofetch", () => {
     expect(onResponse).toHaveBeenCalledTimes(2);
     expect(onResponseError).toHaveBeenCalledTimes(2);
   });
+
+  it("should support method aliases like get, post, put, etc.", async () => {
+    // Test the GET alias
+    expect(await $fetch.get(getURL("ok"))).to.equal("ok");
+
+    // Test the POST alias
+    const { body: postBody } = await $fetch.post(getURL("post"), {
+      body: { test: "post" },
+    });
+    expect(postBody).to.deep.eq({ test: "post" });
+
+    // Test the PUT alias
+    const { body: putBody } = await $fetch.put(getURL("post"), {
+      body: { test: "put" },
+    });
+    expect(putBody).to.deep.eq({ test: "put" });
+
+    // Test the DELETE alias
+    const deleteResponse = await $fetch.delete(getURL("ok"));
+    expect(deleteResponse).to.equal("ok");
+
+    // Test the PATCH alias
+    const { body: patchBody } = await $fetch.patch(getURL("post"), {
+      body: { test: "patch" },
+    });
+    expect(patchBody).to.deep.eq({ test: "patch" });
+  });
 });


### PR DESCRIPTION
This commit refactors the `fetch` function in the `src/fetch.ts` file to add method aliases for common HTTP verbs. The aliases include `get`, `post`, `put`, `delete`, `patch`, `head`, and `options`. These aliases simplify the usage of the `fetch` function by allowing developers to use more intuitive method names instead of manually specifying the HTTP method in the options object.

The changes also include updating the `types.ts` file to define the `FetchWithAliases` type, which extends the existing `$Fetch` type and adds the method aliases as properties.

This enhancement improves the readability and maintainability of the codebase by providing a more expressive and concise API for making HTTP requests. 

Closes #282
