### PR TITLE
test: fix typo

### DIFF
--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -425,7 +425,7 @@ describe("ofetch", () => {
     // onResponse
     await expect(
       $fetch(getURL("/ok"), {
-        onRequest: () => {
+        onResponse: () => {
           throw new Error("error in onResponse");
         },
       })


### PR DESCRIPTION
Looks like line 428 is supposed to be 'onResponse' rather than 'onRequest'.
