### PR TITLE
fix: remove undefined `method` and `query`/`params` from fetch options

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -108,7 +108,9 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
     };
 
     // Uppercase method name
-    context.options.method = context.options.method?.toUpperCase();
+    if (context.options.method) {
+      context.options.method = context.options.method.toUpperCase()
+    }
 
     if (context.options.onRequest) {
       await callHooks(context, context.options.onRequest);
@@ -120,6 +122,13 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
       }
       if (context.options.query) {
         context.request = withQuery(context.request, context.options.query);
+        delete context.options.query;
+      }
+      if ('query' in context.options) {
+        delete context.options.query;
+      }
+      if ('params' in context.options) {
+        delete context.options.params;
       }
     }
 
@@ -146,7 +155,7 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
         // ReadableStream Body
         ("pipeTo" in (context.options.body as ReadableStream) &&
           typeof (context.options.body as ReadableStream).pipeTo ===
-            "function") ||
+          "function") ||
         // Node.js Stream Body
         typeof (context.options.body as Readable).pipe === "function"
       ) {

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -109,7 +109,7 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
 
     // Uppercase method name
     if (context.options.method) {
-      context.options.method = context.options.method.toUpperCase()
+      context.options.method = context.options.method.toUpperCase();
     }
 
     if (context.options.onRequest) {
@@ -124,10 +124,10 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
         context.request = withQuery(context.request, context.options.query);
         delete context.options.query;
       }
-      if ('query' in context.options) {
+      if ("query" in context.options) {
         delete context.options.query;
       }
-      if ('params' in context.options) {
+      if ("params" in context.options) {
         delete context.options.params;
       }
     }
@@ -155,7 +155,7 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
         // ReadableStream Body
         ("pipeTo" in (context.options.body as ReadableStream) &&
           typeof (context.options.body as ReadableStream).pipeTo ===
-          "function") ||
+            "function") ||
         // Node.js Stream Body
         typeof (context.options.body as Readable).pipe === "function"
       ) {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,7 +9,15 @@ import {
   readRawBody,
   toNodeListener,
 } from "h3";
-import { describe, beforeEach, beforeAll, afterAll, it, expect, vi } from "vitest";
+import {
+  describe,
+  beforeEach,
+  beforeAll,
+  afterAll,
+  it,
+  expect,
+  vi,
+} from "vitest";
 import { Headers, FormData, Blob } from "node-fetch-native";
 import { nodeMajorVersion } from "std-env";
 import { $fetch } from "../src/node";
@@ -18,7 +26,7 @@ describe("ofetch", () => {
   let listener;
   const getURL = (url) => joinURL(listener.url, url);
 
-  const fetch = vi.spyOn(globalThis, "fetch")
+  const fetch = vi.spyOn(globalThis, "fetch");
 
   beforeAll(async () => {
     const app = createApp()
@@ -92,8 +100,8 @@ describe("ofetch", () => {
   });
 
   beforeEach(() => {
-    fetch.mockClear()
-  })
+    fetch.mockClear();
+  });
 
   it("ok", async () => {
     expect(await $fetch(getURL("ok"))).to.equal("ok");
@@ -517,12 +525,12 @@ describe("ofetch", () => {
     expect(onResponseError).toHaveBeenCalledTimes(2);
   });
 
-  it('default fetch options', async () => {
-    await $fetch('https://jsonplaceholder.typicode.com/todos/1', {})
-    expect(fetch).toHaveBeenCalledOnce()
-    const options = fetch.mock.calls[0][1]
+  it("default fetch options", async () => {
+    await $fetch("https://jsonplaceholder.typicode.com/todos/1", {});
+    expect(fetch).toHaveBeenCalledOnce();
+    const options = fetch.mock.calls[0][1];
     expect(options).toStrictEqual({
       headers: expect.any(Headers),
-    })
-  })
+    });
+  });
 });

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -9,7 +9,7 @@ import {
   readRawBody,
   toNodeListener,
 } from "h3";
-import { describe, beforeAll, afterAll, it, expect, vi } from "vitest";
+import { describe, beforeEach, beforeAll, afterAll, it, expect, vi } from "vitest";
 import { Headers, FormData, Blob } from "node-fetch-native";
 import { nodeMajorVersion } from "std-env";
 import { $fetch } from "../src/node";
@@ -17,6 +17,8 @@ import { $fetch } from "../src/node";
 describe("ofetch", () => {
   let listener;
   const getURL = (url) => joinURL(listener.url, url);
+
+  const fetch = vi.spyOn(globalThis, "fetch")
 
   beforeAll(async () => {
     const app = createApp()
@@ -88,6 +90,10 @@ describe("ofetch", () => {
   afterAll(() => {
     listener.close().catch(console.error);
   });
+
+  beforeEach(() => {
+    fetch.mockClear()
+  })
 
   it("ok", async () => {
     expect(await $fetch(getURL("ok"))).to.equal("ok");
@@ -510,4 +516,13 @@ describe("ofetch", () => {
     expect(onResponse).toHaveBeenCalledTimes(2);
     expect(onResponseError).toHaveBeenCalledTimes(2);
   });
+
+  it('default fetch options', async () => {
+    await $fetch('https://jsonplaceholder.typicode.com/todos/1', {})
+    expect(fetch).toHaveBeenCalledOnce()
+    const options = fetch.mock.calls[0][1]
+    expect(options).toStrictEqual({
+      headers: expect.any(Headers),
+    })
+  })
 });


### PR DESCRIPTION
Context: https://github.com/nuxt/nuxt/pull/29052

> fetch manifest.json in chrome 63. Request method has no default value at ofetch lib, it will returen 400 Bad reuqest.

I haven't tested on legacy Chrome versions and it seems something we don't need to by spec but for the sake of simplicity. 

