### PR TITLE
docs(readme):  use `ProxyAgent` in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,12 +346,12 @@ const data = await ofetch("https://icanhazip.com");
 **Example:** Allow self-signed certificates (USE AT YOUR OWN RISK!)
 
 ```ts
-import { Agent } from "undici";
+import { ProxyAgent } from "undici";
 import { ofetch } from "ofetch";
 
 // Note: This makes fetch unsecure against MITM attacks. USE AT YOUW OWN RISK!
-const unsecureAgent = new Agent({ connect: { rejectUnauthorized: false } });
-const unsecureFetch = ofetch.create({ dispatcher: unsecureAgent });
+const unsecureProxyAgent = new ProxyAgent({ requestTls: { rejectUnauthorized: false } });
+const unsecureFetch = ofetch.create({ dispatcher: unsecureProxyAgent });
 
 const data = await unsecureFetch("https://www.squid-cache.org/");
 ```


### PR DESCRIPTION
Changed `Agent` to `ProxyAgent` in the READMEs self-signed certificate example. This changes should help with consistency, as all other examples use the `ProxyAgent` and the `Agent` misses a lot of essential proxy functionality that would probably be used in combination with self-signed certs like the `uri` option.