### PR TITLE
fix: mark `FormData` & `URLSearchParams` as non-serializable for bun compatibility

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,6 +31,12 @@ export function isJSONSerializable(value: any) {
   if (value.buffer) {
     return false;
   }
+  // FormData should't be JSON serializable,
+  // but `Bun` adds a `toJSON` method to it, which is not standard.
+  // issue: https://github.com/unjs/ofetch/issues/439
+  if(value instanceof FormData) {
+    return false;
+  }
   return (
     (value.constructor && value.constructor.name === "Object") ||
     typeof value.toJSON === "function"

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,7 +34,7 @@ export function isJSONSerializable(value: any) {
   // FormData should't be JSON serializable,
   // but `Bun` adds a `toJSON` method to it, which is not standard.
   // issue: https://github.com/unjs/ofetch/issues/439
-  if(value instanceof FormData) {
+  if (value instanceof FormData) {
     return false;
   }
   return (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -31,10 +31,9 @@ export function isJSONSerializable(value: any) {
   if (value.buffer) {
     return false;
   }
-  // FormData should't be JSON serializable,
-  // but `Bun` adds a `toJSON` method to it, which is not standard.
-  // issue: https://github.com/unjs/ofetch/issues/439
-  if (value instanceof FormData) {
+  // `FormData` and `URLSearchParams` should't have a `toJSON` method,
+  // but Bun adds it, which is non-standard.
+  if (value instanceof FormData || value instanceof URLSearchParams) {
     return false;
   }
   return (


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

resolves #439
resolves #466

Bun added `toJSON` method to `URLSearchParams` and `FormData`, this confused the `isJSONSerializable`.

It’s neither Node.js behavior (Bun aims for 100% compatibility) nor standard behavior (according to MDN)
