### PR TITLE
chore: provide `https` instead of `http`

### DIFF
--- a/playground/index.mjs
+++ b/playground/index.mjs
@@ -1,7 +1,7 @@
 import { $fetch } from "..";
 
 async function main() {
-  await $fetch("http://google.com/404");
+  await $fetch("https://google.com/404");
 }
 
 // eslint-disable-next-line unicorn/prefer-top-level-await

--- a/playground/index.ts
+++ b/playground/index.ts
@@ -1,9 +1,9 @@
 import { $fetch } from "../src/node";
 
 async function main() {
-  // const r = await $fetch<string>('http://google.com/404')
-  const r = await $fetch<string>("http://httpstat.us/500");
-  // const r = await $fetch<string>('http://httpstat/500')
+  // const r = await $fetch<string>('https://google.com/404')
+  const r = await $fetch<string>("https://httpstat.us/500");
+  // const r = await $fetch<string>('https://httpstat/500')
 
   console.log(r);
 }


### PR DESCRIPTION
Here I think we can provide `https`. It works with `http`, but in the google chrome browser it shows not secure. That's why I think may be we can give `https` in those links.