### PR TITLE
feat: support custom `AbortSignal` with `timeout`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.idea
 node_modules
 *.log
 .DS_Store

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -35,11 +35,8 @@ const retryStatusCodes = new Set([
 const nullBodyResponses = new Set([101, 204, 205, 304]);
 
 export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
-  const {
-    fetch = globalThis.fetch,
-    Headers = globalThis.Headers,
-    AbortController = globalThis.AbortController,
-  } = globalOptions;
+  const { fetch = globalThis.fetch, Headers = globalThis.Headers } =
+    globalOptions;
 
   async function onError(context: FetchContext): Promise<FetchResponse<any>> {
     // Is Abort
@@ -166,12 +163,17 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
       }
     }
 
-    const mergedSignal = AbortSignal.any([
-      typeof context.options.timeout === "number" ? AbortSignal.timeout(context.options.timeout) : undefined,
-      context.options.signal,
-    ].filter((s): s is NonNullable<typeof s> => Boolean(s)))
+    const mergedSignal = AbortSignal.any(
+      [
+        typeof context.options.timeout === "number"
+          ? AbortSignal.timeout(context.options.timeout)
+          : undefined,
+        context.options.signal,
+        // eslint-disable-next-line unicorn/prefer-native-coercion-functions
+      ].filter((s): s is NonNullable<typeof s> => Boolean(s))
+    );
 
-    context.options.signal = mergedSignal
+    context.options.signal = mergedSignal;
 
     try {
       context.response = await fetch(

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -35,8 +35,11 @@ const retryStatusCodes = new Set([
 const nullBodyResponses = new Set([101, 204, 205, 304]);
 
 export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
-  const { fetch = globalThis.fetch, Headers = globalThis.Headers } =
-    globalOptions;
+  const {
+    fetch = globalThis.fetch,
+    Headers = globalThis.Headers,
+    AbortController = globalThis.AbortController,
+  } = globalOptions;
 
   async function onError(context: FetchContext): Promise<FetchResponse<any>> {
     // Is Abort
@@ -169,6 +172,7 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
           ? AbortSignal.timeout(context.options.timeout)
           : undefined,
         context.options.signal,
+        AbortController.signal,
         // eslint-disable-next-line unicorn/prefer-native-coercion-functions
       ].filter((s): s is NonNullable<typeof s> => Boolean(s))
     );

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -531,6 +531,7 @@ describe("ofetch", () => {
     const options = fetch.mock.calls[0][1];
     expect(options).toStrictEqual({
       headers: expect.any(Headers),
+      signal: expect.any(AbortSignal),
     });
   });
 });


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This PR uses a `AbortSignal.timeout()` merged with an optional `options.signal` with `AbortSignal.any()`

resolves https://github.com/unjs/ofetch/issues/326

This should make the following obsolete: https://github.com/unjs/ofetch/pull/481.