### PR TITLE
Add retryCondition Option

### DIFF
--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -60,12 +60,19 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
       }
 
       const responseCode = (context.response && context.response.status) || 500;
-      if (
-        retries > 0 &&
-        (Array.isArray(context.options.retryStatusCodes)
-          ? context.options.retryStatusCodes.includes(responseCode)
-          : retryStatusCodes.has(responseCode))
-      ) {
+
+      const isRetryableStatus = Array.isArray(context.options.retryStatusCodes)
+        ? context.options.retryStatusCodes.includes(responseCode)
+        : retryStatusCodes.has(responseCode);
+
+      const isConditionalRetry =
+        typeof context.options.retryCondition === "function"
+          ? await context.options.retryCondition(context)
+          : false;
+
+      const shouldRetry = isRetryableStatus || isConditionalRetry;
+
+      if (retries > 0 && shouldRetry) {
         const retryDelay =
           typeof context.options.retryDelay === "function"
             ? context.options.retryDelay(context)

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,12 @@ export interface FetchOptions<R extends ResponseType = ResponseType, T = any>
 
   /** Default is [408, 409, 425, 429, 500, 502, 503, 504] */
   retryStatusCodes?: number[];
+
+  /**
+   * Condition to retry the request.
+   * @default false
+   */
+  retryCondition?: (context: FetchContext<T, R>) => boolean | Promise<boolean>;
 }
 
 export interface ResolvedFetchOptions<

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -377,6 +377,93 @@ describe("ofetch", () => {
     });
   });
 
+  it("retries when retryCondition (sync) returns true", async () => {
+    let called = 0;
+    await $fetch(getURL("408"), {
+      retry: 2,
+      retryCondition: () => {
+        called++;
+        return true;
+      },
+    }).catch(() => "failed");
+    expect(called).to.equal(3);
+  });
+
+  it("retries when retryCondition (async) returns true", async () => {
+    let called = 0;
+    await $fetch(getURL("408"), {
+      retry: 2,
+      retryCondition: async () => {
+        called++;
+        return true;
+      },
+    }).catch(() => "failed");
+    expect(called).to.equal(3);
+  });
+
+  it("does not retry when retryCondition returns false and status does not match", async () => {
+    let called = 0;
+    await $fetch(getURL("404"), {
+      retry: 2,
+      retryCondition: () => {
+        called++;
+        return false;
+      },
+    }).catch(() => "failed");
+    expect(called).to.equal(1);
+  });
+
+  it("retries on matching status even if retryCondition returns false", async () => {
+    let called = 0;
+    await $fetch(getURL("408"), {
+      retry: 2,
+      retryCondition: () => {
+        called++;
+        return false;
+      },
+    }).catch(() => "failed");
+    expect(called).to.equal(3);
+  });
+
+  it("throws if retryCondition throws (consumer error) propagates error to consumer", async () => {
+    let called = 0;
+    await expect(
+      $fetch(getURL("408"), {
+        retry: 2,
+        retryCondition: () => {
+          called++;
+          throw new Error("bad predicate");
+        },
+      })
+    ).rejects.toThrow("bad predicate");
+    expect(called).to.equal(1);
+  });
+
+  it("retries when both retryStatusCodes and retryCondition allow", async () => {
+    let called = 0;
+    await $fetch(getURL("408"), {
+      retry: 2,
+      retryStatusCodes: [408],
+      retryCondition: () => {
+        called++;
+        return true;
+      },
+    }).catch(() => "failed");
+    expect(called).to.equal(3);
+  });
+
+  it("retries when only retryStatusCodes match and retryCondition is absent", async () => {
+    let called = 0;
+    await $fetch(getURL("408"), {
+      retry: 2,
+      retryStatusCodes: [408],
+      onResponseError: () => {
+        called++;
+      },
+    }).catch(() => "failed");
+    expect(called).to.equal(3);
+  });
+
   it("deep merges defaultOptions", async () => {
     const _customFetch = $fetch.create({
       query: {


### PR DESCRIPTION
Resolves #503

## Summary

This PR adds support for `retryCondition` option for `$fetch`.

### What’s new
- Introduces `retryCondition(context)` callback for custom retry logic.
- Keeps `retryStatusCodes` and `retryCondition` independent — retries if **either** is satisfied.
- If `retryCondition` throws, the error is propagated to the consumer.
- Functionality is verified via unit tests

## Example

```ts
await $fetch('/api/data', {
  retry: 3,
  retryCondition: (ctx) => {
    // Retry until response body contains expected field
    return ctx.response?._data?.status !== 'ready';
  }
});