### PR TITLE
fix: correct isJSONSerializable to handle null without throwing

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,7 +19,7 @@ export function isJSONSerializable(value: any): boolean {
     return false;
   }
   const t = typeof value;
-  if (t === "string" || t === "number" || t === "boolean" || t === null) {
+  if (t === "string" || t === "number" || t === "boolean" || value === null) {
     return true;
   }
   if (t !== "object") {

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,6 +10,7 @@ import {
 import { Readable } from "node:stream";
 import { H3, HTTPError, readBody, serve } from "h3";
 import { $fetch } from "../src/index.ts";
+import { isJSONSerializable } from "../src/utils.ts";
 
 describe("ofetch", () => {
   let listener: ReturnType<typeof serve>;
@@ -156,6 +157,10 @@ describe("ofetch", () => {
       expect(headers).to.include({ "x-header": "1" });
       expect(headers).to.include({ accept: "application/json" });
     }
+  });
+
+  it("treats null as JSON serializable", () => {
+    expect(isJSONSerializable(null)).toBe(true); // eslint-disable-line unicorn/no-null
   });
 
   it("does not stringify body when content type != application/json", async () => {


### PR DESCRIPTION
## Problem

isJSONSerializable(null) throws a TypeError and incorrectly returns 
alse.

### Root cause

```typescript
// src/utils.ts
const t = typeof value;
if (t === "string" || t === "number" || t === "boolean" || t === null) {
  return true;
}
// ...
if (value.buffer) { // <-- throws TypeError when value is null
```

Two bugs on the same line:

1. **Dead code**: 	ypeof value never returns "null" — it returns "object" for 
ull. So 	 === null can never be 	rue.
2. **Throws on null**: Since the early-return check is never triggered for 
ull, execution continues to 
alue.buffer, which throws TypeError: Cannot read properties of null (reading 'buffer').

Verified: 
ull is valid JSON (JSON.stringify(null) → "null"), so the function should return 	rue for it.

## Fix

Replace 	 === null with 
alue === null:

```typescript
// Before
if (t === "string" || t === "number" || t === "boolean" || t === null) {

// After
if (t === "string" || t === "number" || t === "boolean" || value === null) {
```

This correctly checks the value itself rather than its 	ypeof result, so 
ull hits the early 
eturn true before reaching 
alue.buffer.

Fixes #571

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed JSON serializability checks so `null` is correctly treated as a valid JSON value.
* **Tests**
  * Added coverage confirming that `null` returns `true` in the JSON serializability check.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->