### PR TITLE
fix: detect `+xml` content types as text

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -75,7 +75,11 @@ export function detectResponseType(_contentType = ""): ResponseType {
     return "stream";
   }
 
-  if (textTypes.has(contentType) || contentType.startsWith("text/")) {
+  if (
+    textTypes.has(contentType) ||
+    contentType.startsWith("text/") ||
+    contentType.endsWith("+xml")
+  ) {
     return "text";
   }
 

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -47,6 +47,10 @@ describe("ofetch", () => {
         event.res.headers.set("Content-Type", "application/octet-stream");
         return new Blob(["binary"]);
       })
+      .all("/rss", (event) => {
+        event.res.headers.set("Content-Type", "application/rss+xml");
+        return "<rss></rss>";
+      })
       .all(
         "/403",
         () => new HTTPError({ status: 403, statusMessage: "Forbidden" })
@@ -108,6 +112,10 @@ describe("ofetch", () => {
 
   it("returns a blob for binary content-type", async () => {
     expect(await $fetch(getURL("binary"))).to.be.instanceOf(Blob);
+  });
+
+  it("returns text for +xml content-type", async () => {
+    expect(await $fetch(getURL("rss"))).to.equal("<rss></rss>");
   });
 
   it("baseURL", async () => {


### PR DESCRIPTION
Fixes #597.

`detectResponseType` only treated a fixed set of content types as text (`application/xml`, `application/xhtml` and so on) plus anything starting with `text/`. Subtypes with a `+xml` suffix like `application/rss+xml` or `application/atom+xml` fell through to `blob`, so an RSS feed came back as a `Blob` instead of a string.

This adds a `+xml` suffix check alongside the existing ones, mirroring how JSON already matches `+json` subtypes. Added a test that an `application/rss+xml` response is parsed as text.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved response handling for XML-based content types, ensuring formats such as RSS are returned as readable text.
* **Tests**
  * Added coverage for responses using `+xml` media types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->