### PR TITLE
fix: add rss+xml to textTypes, fix isJSONSerializable(null)

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,9 @@ export function isJSONSerializable(value: any): boolean {
   if (t !== "object") {
     return false; // bigint, function, symbol, undefined
   }
+  if (value === null) {
+    return true;
+  }
   if (Array.isArray(value)) {
     return true;
   }
@@ -47,6 +50,8 @@ const textTypes = new Set([
   "application/xml",
   "application/xhtml",
   "application/html",
+  "application/rss+xml",
+  "application/atom+xml",
 ]);
 
 const JSON_RE = /^application\/(?:[\w!#$%&*.^`~-]*\+)?json(;.+)?$/i;


### PR DESCRIPTION
## Changes

**#597** — RSS feeds with `application/rss+xml` (and `application/atom+xml`) returned as Blob instead of text. Added both to the `textTypes` set so `detectResponseType` returns `"text"`.

**#571** — `isJSONSerializable(null)` threw `Cannot read properties of null (reading 'buffer')` because `typeof null === 'object'`, so null passed the type checks and crashed at `value.buffer`. Added an explicit `value === null` guard returning `true` (null is JSON-serializable).

## Tests
All 28 existing tests pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Correctly recognizes `null` values as JSON-serializable.
  * Properly handles RSS and Atom feed responses as text instead of binary content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->