### PR TITLE
feat: support ignoring specific response status errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,10 +91,12 @@ To catch error response:
 await ofetch("/url").catch((error) => error.data);
 ```
 
-To bypass status error catching you can set `ignoreResponseError` option:
+To bypass status error catching you can set `ignoreResponseError` to `true`, or
+provide the status codes to bypass:
 
 ```ts
 await ofetch("/url", { ignoreResponseError: true });
+await ofetch("/url", { ignoreResponseError: [403, 404] });
 ```
 
 ## ✔️ Auto Retry

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -239,8 +239,14 @@ export function createFetch(globalOptions: CreateFetchOptions = {}): $Fetch {
       );
     }
 
+    const ignoreResponseError = context.options.ignoreResponseError;
+    const doIgnoreResponseError =
+      ignoreResponseError === true ||
+      (Array.isArray(ignoreResponseError) &&
+        ignoreResponseError.includes(context.response.status));
+
     if (
-      !context.options.ignoreResponseError &&
+      !doIgnoreResponseError &&
       context.response.status >= 400 &&
       context.response.status < 600
     ) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,7 +26,7 @@ export interface FetchOptions<R extends ResponseType = ResponseType, T = any>
 
   body?: RequestInit["body"] | Record<string, any>;
 
-  ignoreResponseError?: boolean;
+  ignoreResponseError?: boolean | number[];
 
   /**
    * @deprecated use query instead.

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -250,6 +250,16 @@ describe("ofetch", () => {
     expect(res?.message).to.eq("Forbidden");
   });
 
+  it("ignores configured response error status codes", async () => {
+    const res = await $fetch(getURL("403"), { ignoreResponseError: [403] });
+    expect(res?.status).to.eq(403);
+    expect(res?.message).to.eq("Forbidden");
+
+    await expect(
+      $fetch(getURL("408"), { ignoreResponseError: [403] })
+    ).rejects.toThrow("408");
+  });
+
   it("204 no content", async () => {
     const res = await $fetch(getURL("204"));
     expect(res).toBe(undefined);


### PR DESCRIPTION
## Summary

- Allow callers to bypass response errors for selected HTTP status codes.
- Keep error handling enabled for statuses that are not explicitly selected.

## Testing

- pnpm vitest run test/index.test.ts
- pnpm exec tsc --noEmit